### PR TITLE
docs(product): Meal Planner Sprint 0 — North Star, roadmap and decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,28 @@ GitHub: [https://github.com/maciak-dev/meal-planner](https://github.com/maciak-d
 
 ---
 
+## Documentation
+
+Product documentation is organised from product to implementation:
+
+```
+North Star → Vision → Modules → Integrations → Architecture → Operations
+```
+
+- [Documentation index](docs/README.md) — single entry point
+- [North Star](docs/north-star.md) — what Meal Planner is and is not; the
+  criterion every feature is judged against
+- [Product vision](docs/product/vision.md), [roadmap](docs/product/roadmap.md),
+  [backlog](docs/product/backlog.md)
+- [Integration with MAP](docs/integrations/map.md) — boundaries and contract
+- [Production Guardrails](docs/operations/production-guardrails.md) — read
+  before touching anything production-related
+
+The section below describes the current implementation, which is narrower than
+the product direction set out in the North Star.
+
+---
+
 ## Features
 
 - User login & role-based access (`user` / `admin`) 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # 🍽️ Meal Planner
 
-Simple recipe manager built with **FastAPI**, **SQLAlchemy**, and **JWT authentication**.
+**Plan meals. Build the shopping list. Know what's for dinner.**
+
+Built with **FastAPI**, **SQLAlchemy**, and **JWT authentication**.
 
 GitHub: [https://github.com/maciak-dev/meal-planner](https://github.com/maciak-dev/meal-planner)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,8 @@ North Star → Vision → Modules → Integrations → Architecture → Operatio
 - [ADR-003](decisions/ADR-003.md) — agregacja tylko przy zgodnej nazwie i
   jednostce
 - [ADR-004](decisions/ADR-004.md) — porcje i czasy utrwalane w modelu przepisu
+- [ADR-005](decisions/ADR-005.md) — integracja z MAP jako kontrakt read-only
+  w v1
 
 ## Architecture
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,8 @@ North Star → Vision → Modules → Integrations → Architecture → Operatio
    wyjściowy i diagnoza
 4. [Roadmap](product/roadmap.md) — Sprint 0, Sprint 1, decyzje do podjęcia
 5. [Backlog](product/backlog.md)
-6. [Integracja z MAP](integrations/map.md) — granice i kontrakt
+6. [Rejestr decyzji](decisions/README.md) — ADR-001 … ADR-004
+7. [Integracja z MAP](integrations/map.md) — granice i kontrakt
 
 ## Modules
 
@@ -39,6 +40,16 @@ North Star → Vision → Modules → Integrations → Architecture → Operatio
 ## Product
 
 - [Projekt dashboardu](product/dashboard.md) — specyfikacja wejściowa Sprintu 2
+
+## Decisions
+
+- [Rejestr decyzji](decisions/README.md)
+- [ADR-001](decisions/ADR-001.md) — jeden slot posiłkowy dziennie w v1
+- [ADR-002](decisions/ADR-002.md) — plan i lista należą do gospodarstwa, nie do
+  użytkownika
+- [ADR-003](decisions/ADR-003.md) — agregacja tylko przy zgodnej nazwie i
+  jednostce
+- [ADR-004](decisions/ADR-004.md) — porcje i czasy utrwalane w modelu przepisu
 
 ## Architecture
 
@@ -70,8 +81,9 @@ zaakceptowaniu tamtej zmiany:
 
 - `docs/architecture/recipe-import.md`
 - `docs/architecture/ingredient-model.md`
-- `docs/decisions/recipe-translations.md`
-- `docs/decisions/ingredient-normalization.md`
+- `docs/decisions/recipe-translations.md` — do przenumerowania na **ADR-005**
+- `docs/decisions/ingredient-normalization.md` — do przenumerowania na
+  **ADR-006**
 - `docs/handoffs/i18n-recipe-import-ingredients.md`
 - `docs/product/bilingual-recipe-import.md`
 - `docs/audits/meal-planner-production-rollout-ready-2026-08-05.md`
@@ -81,14 +93,14 @@ zaakceptowaniu tamtej zmiany:
 - Kierunek produktu: [north-star.md](north-star.md)
 - Aktywny plan: [product/roadmap.md](product/roadmap.md)
 - Priorytetyzowany backlog: [product/backlog.md](product/backlog.md)
+- Decyzje: [decisions/README.md](decisions/README.md)
 - Granice wobec MAP: [integrations/map.md](integrations/map.md)
 - Dokumentacja modułów: [modules/](modules/README.md)
 
 ## Zasady dokumentacji
 
-1. `product/roadmap.md`, `product/backlog.md` i katalog `decisions/` (wraca do
-   tej hierarchii razem z branchem `feature/i18n-recipe-import-ingredients`)
-   pozostają jedynym źródłem prawdy dla aktywnego planu, backlogu i decyzji.
+1. `product/roadmap.md`, `product/backlog.md` i `decisions/` pozostają jedynym
+   źródłem prawdy dla aktywnego planu, backlogu i decyzji.
 2. Każdy nowy moduł dostaje dokument w `modules/`.
 3. Dokumenty aktywne mają `status` i `last_updated` we frontmatterze.
 4. Nie utrzymujemy dwóch źródeł prawdy dla tego samego aktywnego tematu.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,99 @@
+---
+status: Active
+last_updated: 2026-08-07
+---
+
+# Meal Planner Documentation
+
+Ten katalog jest jedynym punktem wejścia do aktywnej dokumentacji projektu.
+
+Dokumentacja jest zorganizowana od produktu do implementacji — nigdy odwrotnie:
+
+```
+North Star → Vision → Modules → Integrations → Architecture → Operations
+```
+
+## Start Here
+
+1. [North Star](north-star.md) — najważniejszy dokument projektu
+2. [Product vision](product/vision.md) — jaki problem rozwiązujemy
+3. [Audyt produktowy 2026-08-07](audits/product-audit-2026-08-07.md) — stan
+   wyjściowy i diagnoza
+4. [Roadmap](product/roadmap.md) — Sprint 0, Sprint 1, decyzje do podjęcia
+5. [Backlog](product/backlog.md)
+6. [Integracja z MAP](integrations/map.md) — granice i kontrakt
+
+## Modules
+
+- [Portfolio modułów](modules/README.md) — cel, priorytet, status, kierunek
+- [Plan posiłków](modules/meal-plan.md) _(planowany)_
+- [Lista zakupów](modules/shopping-list.md)
+- [Dashboard](modules/dashboard.md) _(planowany)_
+- [Przepisy](modules/recipes.md)
+- [Import przepisu z URL](modules/recipe-import.md)
+- [Składniki (normalizacja)](modules/ingredients.md) _(zamrożony)_
+- [Dwujęzyczność PL/EN](modules/i18n.md)
+- [Konta i dostęp](modules/identity.md)
+- [Panel administracyjny i logi](modules/admin.md) _(zamrożony)_
+
+## Product
+
+- [Projekt dashboardu](product/dashboard.md) — specyfikacja wejściowa Sprintu 2
+
+## Architecture
+
+- [Wydzielenie panelu admina](architecture/panel-admin-extraction.md)
+
+## Operations
+
+- [Production Guardrails](operations/production-guardrails.md) — obowiązkowa
+  lektura przed jakąkolwiek zmianą dotykającą produkcji
+- [Środowisko produkcyjne](operations/production-environment.md)
+- [Środowisko RC](operations/rc-environment.md)
+- [Backup i restore PostgreSQL](operations/postgres-backup-restore.md)
+- [Runbook wdrożenia Sprintu 0](operations/sprint-0-production-rollout.md)
+
+## Audits
+
+- [Audyt produktowy 2026-08-07](audits/product-audit-2026-08-07.md)
+- [Audyt produkcyjny 2026-08-04](audits/meal-planner-production-audit.md) —
+  warstwa infrastrukturalna
+- [Przegląd feature'u składników](audits/ingredients-feature-review.md)
+- [Próba wdrożenia 2026-08-05](audits/meal-planner-production-rollout-attempt-2026-08-05.md)
+
+## Dokumenty spoza tego baseline'u
+
+Warstwa produktowa opisuje także pracę, której kod i dokumentacja czekają na
+akceptację na branchu `feature/i18n-recipe-import-ingredients`. Te dokumenty
+**nie są** częścią tego brancha i wejdą do hierarchii dopiero po
+zaakceptowaniu tamtej zmiany:
+
+- `docs/architecture/recipe-import.md`
+- `docs/architecture/ingredient-model.md`
+- `docs/decisions/recipe-translations.md`
+- `docs/decisions/ingredient-normalization.md`
+- `docs/handoffs/i18n-recipe-import-ingredients.md`
+- `docs/product/bilingual-recipe-import.md`
+- `docs/audits/meal-planner-production-rollout-ready-2026-08-05.md`
+
+## Source Of Truth
+
+- Kierunek produktu: [north-star.md](north-star.md)
+- Aktywny plan: [product/roadmap.md](product/roadmap.md)
+- Priorytetyzowany backlog: [product/backlog.md](product/backlog.md)
+- Granice wobec MAP: [integrations/map.md](integrations/map.md)
+- Dokumentacja modułów: [modules/](modules/README.md)
+
+## Zasady dokumentacji
+
+1. `product/roadmap.md`, `product/backlog.md` i katalog `decisions/` (wraca do
+   tej hierarchii razem z branchem `feature/i18n-recipe-import-ingredients`)
+   pozostają jedynym źródłem prawdy dla aktywnego planu, backlogu i decyzji.
+2. Każdy nowy moduł dostaje dokument w `modules/`.
+3. Dokumenty aktywne mają `status` i `last_updated` we frontmatterze.
+4. Nie utrzymujemy dwóch źródeł prawdy dla tego samego aktywnego tematu.
+5. Zamknięte plany schodzą do audytów i handoffów, nie zostają w roadmapie.
+6. `ISSUES.md` w katalogu głównym jest historycznym artefaktem sprzed wizji —
+   jego zawartość została oceniona w
+   [audycie produktowym](audits/product-audit-2026-08-07.md) i przeniesiona do
+   [backlogu](product/backlog.md) albo odrzucona.

--- a/docs/audits/product-audit-2026-08-07.md
+++ b/docs/audits/product-audit-2026-08-07.md
@@ -1,0 +1,371 @@
+---
+status: Sprint 0 deliverable
+last_updated: 2026-08-07
+---
+
+# Meal Planner — Product Audit
+
+Data audytu: 2026-08-07
+Zakres: **audyt produktowy**. Nie code review, nie security review, nie
+architecture review. Oceniany jest produkt: wizja, moduły, wartość, UX,
+przepływy, złożoność.
+
+Metoda: przegląd kodu jako źródła prawdy o zachowaniu produktu (`app/`,
+`app/templates/`, `app/static/recipes.js`, słowniki `app/i18n/`), przegląd
+istniejącej dokumentacji (`docs/`), oraz dane produkcyjne z audytu
+infrastrukturalnego z 2026-08-04. **Nie dotykano** produkcji, RC, bazy, API,
+deploymentu ani konfiguracji.
+
+Branch w chwili audytu: `feature/i18n-recipe-import-ingredients`.
+
+---
+
+## 1. Ocena produktu
+
+**Ocena ogólna: 5/10 jako produkt, 8/10 jako fundament techniczny.**
+
+| Wymiar | Ocena | Uzasadnienie |
+|---|---|---|
+| Zgodność nazwy z produktem | 2/10 | Produkt nazywa się „Meal Planner" i nie zawiera planu |
+| Wartość rdzenia (planowanie) | 1/10 | Nie istnieje: brak tygodnia, dnia, posiłku, historii |
+| Wartość katalogu przepisów | 7/10 | Działa, używany (64 przepisy, 4 autorów), świeżo wzmocniony importem z linku |
+| Wartość listy zakupów | 4/10 | Dobry tryb sklepowy, ale `localStorage`, brak trwałości i brak generowania z planu |
+| UX prowadzenia użytkownika | 3/10 | Brak pierwszego ekranu z odpowiedzią; użytkownik sam musi wiedzieć, co zrobić |
+| Spójność produktu | 4/10 | Dwa motywy, martwe kontrolki, panel admina po angielsku w dwujęzycznej aplikacji |
+| Jakość fundamentu (dane, migracje, testy, ops) | 8/10 | Alembic, 121 testów, rozdzielone prod/RC, backup, runbooki |
+| Gotowość do integracji z MAP | 3/10 | Brak kontraktu; nie ma jeszcze czego pokazać poza liczbą przepisów |
+
+Jednozdaniowa diagnoza: **to jest dobrze zbudowany katalog przepisów z bardzo
+dobrym importem i przyzwoitą listą zakupów, który nosi nazwę produktu, którym
+nie jest.**
+
+---
+
+## 2. Wizja — czy istnieje?
+
+**Nie istnieje jako dokument i nie istnieje jako spójna intencja.**
+
+Dowody:
+
+- `README.md` opisuje produkt jako _„Simple recipe manager"_ — czyli inaczej
+  niż nazwa repozytorium, domeny i katalogu.
+- `ISSUES.md` — jedyny dokument zbliżony do planu produktu — zawiera sześć
+  pozycji, z czego jedna to _„cyberpunk 4–5 linii na tle, które będą mrugać"_,
+  jedna to _„upewnić się, że repozytorium jest gotowe"_, a jedna („składniki
+  ważne/nieważne") jest produktowa. To jest lista życzeń, nie wizja.
+- Dokumentacja `docs/` do dziś zawierała wyłącznie warstwę operacyjną,
+  architektoniczną i audytową — zero warstwy produktowej. Nie było dokumentu,
+  względem którego dałoby się odrzucić pomysł.
+- Ekosystem MAP opisuje Meal Plannera jako „planowanie posiłków"
+  (`MAP/docs/ecosystem.md`), czyli zewnętrzny obserwator zakłada funkcję, której
+  produkt nie ma.
+
+**Czy projekt urósł organicznie? Tak, i widać dokładnie jak.** Kolejność
+powstawania funkcji według historii repo: CRUD przepisów → role i panel admina
+→ logi requestów i blokowanie IP → tryb zakupów i animacje FLIP → dwa motywy →
+import listy zakupów → PostgreSQL → i18n → import przepisu z URL z pełnym SSRF
+guardem → model normalizacji składników.
+
+To jest kolejność napędzana ciekawością techniczną i tym, co akurat było pod
+ręką — nie wartością dla użytkownika. Produkt dostał enterprise'owy request
+logging (318 016 wierszy) i hardening SSRF na poziomie pinowania IP, zanim
+dostał pytanie „co jemy w czwartek".
+
+Nie jest to zarzut wobec jakości tych rzeczy — SSRF guard i warstwa operacyjna
+są zrobione dobrze. Jest to obserwacja o **priorytetach**: brakuje mechanizmu,
+który by je ustawiał. Tym mechanizmem jest [North Star](../north-star.md).
+
+---
+
+## 3. Inwentarz modułów
+
+Pełna analiza per moduł: [modules/README.md](../modules/README.md).
+Poniżej skrót z oceną wartości.
+
+| Moduł | Co daje | Realnie używane | Ocena |
+|---|---|---|---|
+| **Przepisy (CRUD, widoczność, zdjęcia)** | Katalog, na którym stoi wszystko inne | Tak: 64 przepisy, 4 autorów, 58 publicznych, 3 ze zdjęciem | **Kluczowy** |
+| **Import przepisu z URL** | Usuwa największe tarcie wejścia — ręczne przepisywanie | Nowy, jeszcze nie na produkcji | **Kluczowy (enabler)** |
+| **Lista zakupów** | Jedyny moduł z realną wartością „w terenie" (tryb sklepowy) | Tak, ale tylko na jednym urządzeniu | **Kluczowy, ale na złym fundamencie** |
+| **Plan tygodnia** | — | **Nie istnieje** | **Brakujący rdzeń** |
+| **Dashboard** | — | **Nie istnieje** | **Brakujący rdzeń** |
+| **Model składników (normalizacja)** | Docelowo: agregacja i sortowanie listy po działach sklepu | 4 tabele, 0 wierszy, 0 UI | **Uśpiony enabler** |
+| **i18n PL/EN** | Dwujęzyczne UI | UI tak; treść przepisów praktycznie nie | **Połowiczny** |
+| **Konta i role** | Rozdzielenie własności przepisów | Tak, 5 użytkowników | **Fundament** |
+| **Panel admina / logi** | Wgląd operacyjny | Tylko dla operatora | **Poboczny** |
+| **Motywy (cyber/scandi)** | Estetyka | Przełącznik istnieje | **Poboczny, kosztowny** |
+
+Kluczowe: przepisy, import, lista zakupów, plan (do zbudowania), dashboard (do
+zbudowania).
+Poboczne: motywy, panel admina, import listy zakupów przez wklejenie tekstu.
+
+---
+
+## 4. Ocena UX
+
+### 4.1. Czy aplikacja prowadzi użytkownika?
+
+**Nie.** Po zalogowaniu użytkownik trafia na `/recipes-ui` — płaską listę
+wszystkich widocznych przepisów, posortowaną po dacie dodania. Nie ma nagłówka
+z odpowiedzią, nie ma sugestii, nie ma stanu „dziś". Aplikacja pokazuje
+zawartość bazy i czeka.
+
+Cała architektura informacji to dwie zakładki: **Przepisy** i **Lista
+zakupów**. Nic ich nie łączy poza przyciskiem „+ Dodaj do listy" na karcie
+przepisu.
+
+### 4.2. Czy wymaga zbyt wielu kliknięć?
+
+Tak, i to w scenariuszu, który jest sensem produktu. Żeby zebrać zakupy na
+pięć obiadów:
+
+1. zakładka Przepisy →
+2. wyszukaj/przewiń do przepisu →
+3. odznacz składniki, które masz w domu (średnio kilkanaście checkboxów) →
+4. „+ Dodaj do listy" →
+5. **powtórz 2–4 pięć razy**, pamiętając z głowy, które przepisy już wybrałeś →
+6. zakładka Lista zakupów →
+7. ręcznie posprzątaj duplikaty i sprzeczne ilości.
+
+To jest ~40–70 interakcji na tydzień, plus pamięć robocza użytkownika jako
+brakujący komponent systemu. Kartka papieru wygrywa.
+
+Docelowo ta sama czynność powinna wyglądać tak: zaplanuj 5 dni (5 kliknięć) →
+„Generuj listę" (1 kliknięcie).
+
+### 4.3. Co jest nieintuicyjne lub wprost mylące
+
+Znaleziono kilka miejsc, gdzie UI obiecuje coś, czego nie robi. To najgorszy
+rodzaj długu produktowego, bo użytkownik nie wie, że stracił dane.
+
+| # | Zachowanie | Skutek dla użytkownika |
+|---|---|---|
+| P-1 | Formularz „Dodaj przepis" ma przełącznik PRYWATNY/PUBLICZNY, ale `Recipes.actions.create()` nie wysyła `is_public` | Każdy nowy przepis jest prywatny, niezależnie od ustawienia przełącznika |
+| P-2 | `id="edit-is-public"` występuje dwa razy w `recipes.html` (formularz dodawania i modal edycji); `getElementById` zwraca pierwszy | Przełącznik widoczności **w modalu edycji nie działa** — wartość wraca niezmieniona |
+| P-3 | Draft importu zbiera „Porcje", „Czas przygotowania", „Czas gotowania"; `create_recipe_from_import()` ich nie zapisuje (model `Recipe` nie ma takich kolumn) | Użytkownik wpisuje dane, klika „Zapisz przepis", dane znikają bez ostrzeżenia |
+| P-4 | Przełącznik PL/EN zmienia UI, ale UI nigdy nie wysyła `language` przy tworzeniu/edycji przepisu (`data.language or 'pl'`) | Nie da się przez UI stworzyć treści EN dla przepisu. Jedyna droga do tłumaczenia to import z linku. Użytkownik EN widzi polskie przepisy |
+| P-5 | „Składniki" w menu burger wywołuje `openIngredientsModal()`, które pokazuje toast „Funkcja składników wkrótce dostępna" | Pozycja menu prowadząca donikąd, obecna w produkcyjnym UI |
+| P-6 | Oznaczanie składników jako „ważne/nieważne" (`ingredients_map`) — tabela `ingredients` ma 0 wierszy, domyślna wartość to `True` | Wszystkie checkboxy zawsze zaznaczone; funkcja jest niewidoczna i bezczynna |
+| P-7 | Dodanie składnika do listy zakupów bierze **cały tekst linii** jako nazwę pozycji i zwiększa `qty` o 1 przy powtórzeniu | Pozycja „2 łyżki oliwy" z licznikiem 2 znaczy „dwa razy dwie łyżki". Agregacja jest semantycznie błędna |
+| P-8 | Lista zakupów żyje w `localStorage` | Lista zrobiona na laptopie nie istnieje w telefonie w sklepie. To unieważnia najlepiej zrobiony moduł w aplikacji |
+| P-9 | Instrukcje renderowane z atrybutu `data-instructions` w HTML | Długie instrukcje z cudzysłowami/znakami specjalnymi są kruche; brak kroków, brak formatowania |
+| P-10 | Panel administracyjny jest wyłącznie po angielsku i w innym motywie | Niespójność w produkcie, który chwali się dwujęzycznością |
+
+### 4.4. Co jest zrobione dobrze
+
+- **Tryb zakupów** — duże cele dotykowe, przełączniki „zrobione", pozycje
+  odhaczone spadają na dół, animacja FLIP, zabezpieczenie przed przypadkowym
+  usunięciem („dotknij ponownie"). To jest projektowane pod realny kontekst:
+  jedna ręka, koszyk, sklep. Najlepszy fragment UX w aplikacji.
+- **Draft importu** — użytkownik widzi, co system zrozumiał, może poprawić
+  każdą linię składnika, a niepewne pozycje są oznaczone „Sprawdź". Wzorcowe
+  podejście „człowiek zatwierdza, maszyna proponuje".
+- **Komunikaty błędów importu** są zmapowane na zrozumiałe zdania w obu
+  językach zamiast surowych wyjątków.
+
+---
+
+## 5. Ocena dashboardu
+
+**Dashboardu nie ma.** `GET /` przekierowuje zalogowanego użytkownika na
+`/recipes-ui`, czyli na listę przepisów.
+
+Na pytanie **„co dzisiaj powinienem zrobić?"** obecny pierwszy ekran odpowiada:
+_„oto 64 przepisy, posortowane od najnowszego"_. To nie jest odpowiedź, to jest
+zrzut bazy danych.
+
+Żeby dashboard mógł powstać, musi istnieć plan — dziś nie ma czego pokazać poza
+liczbą przepisów. Dlatego dashboard jest w roadmapie **po** planie, nie przed.
+Projekt docelowego ekranu: [product/dashboard.md](../product/dashboard.md).
+
+---
+
+## 6. Przepływy użytkownika
+
+| # | Scenariusz | Wsparcie | Komentarz |
+|---|---|---|---|
+| F-1 | **„Co dziś na obiad?"** | ❌ brak | Rdzeń produktu. Zero wsparcia: brak planu, brak historii, brak sugestii |
+| F-2 | **„Zaplanuj tydzień"** | ❌ brak | Brak modelu tygodnia/dnia/posiłku |
+| F-3 | **„Zrób listę zakupów na tydzień"** | ⚠️ częściowe | Ręcznie, przepis po przepisie, z błędną agregacją ilości (P-7) i bez trwałości (P-8) |
+| F-4 | **„Kup w sklepie"** | ✅ dobre | Najlepszy przepływ w aplikacji — pod warunkiem, że lista jest na tym samym urządzeniu |
+| F-5 | **„Zapisz przepis znaleziony w internecie"** | ✅ dobre | Import z URL: wklej link → podgląd → korekta → zapis. Nowy, jeszcze nie na produkcji |
+| F-6 | **„Dodaj własny przepis"** | ⚠️ przeciętne | Składniki i instrukcje jako wolny tekst; przełącznik widoczności nie działa (P-1) |
+| F-7 | **„Znajdź przepis"** | ⚠️ słabe | Wyszukiwanie tekstowe po stronie klienta na wyrenderowanym tekście. Brak tagów, kategorii, filtrów (moje/publiczne, z importu, ze zdjęciem, czas przygotowania) |
+| F-8 | **„Gotuj według przepisu"** | ⚠️ słabe | Instrukcje w prostym modalu; brak kroków, skalowania porcji, trybu kuchennego |
+| F-9 | **„Podziel się przepisem z domownikiem"** | ❌ zepsute | Widoczność nie działa ani przy tworzeniu, ani przy edycji (P-1, P-2) |
+| F-10 | **„Używaj aplikacji po angielsku"** | ⚠️ połowiczne | UI tak, treść przepisów nie (P-4) |
+
+Wniosek: **produkt dobrze wspiera przepływy zaplecza (F-4, F-5) i nie wspiera
+żadnego z przepływów, które są powodem jego istnienia (F-1, F-2, F-3).**
+
+---
+
+## 7. Architektura produktu
+
+Nie kodu — produktu. Meal Planner ma trzy naturalne warstwy:
+
+```
+   ┌─────────────────────────────────────────────────────────┐
+   │  WARSTWA TREŚCI        katalog przepisów, składniki,     │
+   │  (zaplecze)            tłumaczenia, zdjęcia, import      │
+   │                        ██████████████████████ zbudowana  │
+   ├─────────────────────────────────────────────────────────┤
+   │  WARSTWA DECYZJI       plan tygodnia, dzień, posiłek,    │
+   │  (rdzeń produktu)      historia, sugestie, dashboard     │
+   │                        ░░░░░░░░░░░░░░░░░░░░░░ BRAK       │
+   ├─────────────────────────────────────────────────────────┤
+   │  WARSTWA WYKONANIA     lista zakupów, tryb sklepowy,     │
+   │  (w terenie)           tryb gotowania                    │
+   │                        ████████░░░░░░░░░░░░░░ częściowo  │
+   └─────────────────────────────────────────────────────────┘
+```
+
+Warstwa decyzji jest **jednocześnie rdzeniem produktu i jedyną, która nie
+istnieje**. Skutek jest strukturalny, nie kosmetyczny: warstwa treści i
+warstwa wykonania nie mają się przez co komunikować, więc łączy je prowizorka
+— przycisk „+ Dodaj do listy" i pamięć użytkownika.
+
+To wyjaśnia większość znalezisk UX. Błędna agregacja ilości (P-7), brak
+trwałości listy (P-8), brak sensu dla sekcji sklepowych, martwa flaga
+„składnik ważny" (P-6) — wszystkie te rzeczy są objawami jednej przyczyny:
+**nie ma bytu, który wie, ile posiłków planujemy i z czego.**
+
+Warstwa platformy (konta, role, logi, motywy, blokowanie IP, i18n) jest
+rozwinięta nieproporcjonalnie do warstwy produktu.
+
+---
+
+## 8. Gdzie produkt stał się zbyt skomplikowany
+
+| # | Miejsce | Na czym polega nadmiar |
+|---|---|---|
+| Z-1 | **Model składników** | Cztery tabele (`ingredients`, `ingredient_aliases`, `recipe_ingredients`, `store_sections`) zaprojektowane, zmigrowane i udokumentowane ADR-em, zanim istnieje konsument tych danych. `store_sections` służą sortowaniu listy zakupów po działach sklepu — a lista zakupów jest w `localStorage` i nie ma pojęcia o składnikach |
+| Z-2 | **Cztery reprezentacje tej samej treści przepisu** | `Recipe.name/description/instructions` (legacy) + `recipe_translations` (nowy model) + `Recipe.ingredients` (tekst) + `recipe_ingredients` (relacyjne). Import zapisuje do wszystkich czterech. Każda zmiana treści musi teraz pamiętać o czterech miejscach |
+| Z-3 | **Dwa motywy graficzne** | `themes.css` (8 KB) + `main.css` (30 KB) + `admin.css` (7 KB). Każda zmiana UI to podwójna weryfikacja. Motyw „cyber" jest estetycznie sprzeczny z produktem o jedzeniu |
+| Z-4 | **Telemetria bezpieczeństwa** | Logowanie wszystkich requestów (318 016 wierszy, zdominowane przez skany botów), wykrywanie podejrzanych ścieżek, blokowanie IP, panel z filtrami i zakresami dat — w aplikacji z pięcioma kontami |
+| Z-5 | **Formularz draftu importu** | 12 pól, z czego 3 są po zapisie wyrzucane (P-3), plus tabela składników z 6 kolumnami i przełącznik „zapisz składniki jako relacyjne", którego znaczenia użytkownik nie zna |
+| Z-6 | **Dwa niezależne importy** | „Importuj z linku" (przepis) i „Dodaj listę" (wklejona lista zakupów) — dwa różne mechanizmy o podobnej nazwie w dwóch zakładkach |
+
+Wspólny mianownik Z-1, Z-2 i Z-5: **zbudowano poprawną strukturę danych na
+zapas i teraz trzeba ją utrzymywać, zanim cokolwiek z niej korzysta.**
+
+---
+
+## 9. Funkcje widoczne dla użytkownika, ale praktycznie nieużywane
+
+| Funkcja | Stan | Rekomendacja |
+|---|---|---|
+| „Składniki" w menu burger | Toast „wkrótce" (P-5) | **Usunąć** do czasu, gdy będzie działać |
+| Przełącznik PRYWATNY/PUBLICZNY (dodawanie) | Nie wysyła wartości (P-1) | **Naprawić** — funkcja ma sens |
+| Przełącznik PRYWATNY/PUBLICZNY (edycja) | Podpięty pod zły element (P-2) | **Naprawić** |
+| `PATCH /api/v1/recipes/{id}/visibility` + `toggleVisibility()` + `renderVisibilitySwitch()` | Martwy kod — żadna ścieżka UI tego nie wywołuje | **Usunąć** jedną z dwóch dróg zmiany widoczności |
+| Ważność składnika (`is_essential`) | 0 wierszy w tabeli, zawsze `True` (P-6) | **Odłożyć** do czasu serwerowej listy zakupów |
+| Pola „Porcje / Czas przygotowania / Czas gotowania" w imporcie | Zbierane i wyrzucane (P-3) | **Zapisać albo usunąć z formularza** — stan pośredni jest najgorszy |
+| Przełącznik motywu | Kosmetyka bez wartości produktowej (Z-3) | **Wybrać jeden motyw** |
+| Przełącznik PL/EN dla treści przepisu | Nieosiągalny przez UI (P-4) | **Dokończyć** — inaczej dwujęzyczność jest fasadą |
+| „Dodaj listę" (import listy przez wklejenie) | Obejście braku generowania listy z planu | **Zachować jako awaryjne**, przestanie być potrzebne po Sprincie 1 |
+| Filtry logów requestów w panelu admina | Wartość wyłącznie operacyjna, zdominowane szumem botów | **Ograniczyć** zakres i dodać retencję |
+| Swagger `/docs` dla admina | Narzędzie deweloperskie w produkcie | Zostawić, bez rozwoju |
+
+---
+
+## 10. Co można uprościć
+
+1. **Jedna droga zmiany widoczności** zamiast dwóch (formularz + PATCH), jeden
+   działający przełącznik zamiast dwóch zepsutych.
+2. **Jedno źródło prawdy dla treści przepisu** — `recipe_translations` po
+   backfillu; legacy kolumny stają się mirrorem tylko do odczytu, docelowo
+   znikają.
+3. **Jeden motyw.** Usunięcie drugiego to natychmiastowa oszczędność w każdej
+   przyszłej zmianie UI.
+4. **Odłożyć aliasy składników i sekcje sklepowe** do momentu, w którym istnieje
+   serwerowa lista zakupów, która ma je z czego sortować.
+5. **Panel admina do dwóch rzeczy**: kto się logował i co się zepsuło. Retencja
+   `request_log` (np. 30 dni) plus wyłączenie logowania szumu skanowania.
+6. **Instrukcje jako lista kroków** zamiast jednego pola tekstowego renderowanego
+   z atrybutu HTML.
+7. **Usunąć albo dokończyć** wszystkie pozycje z sekcji 9 — produkt nie może
+   pokazywać kontrolek, które nic nie robią. To jedna z najtańszych i
+   najbardziej odczuwalnych poprawek jakości.
+8. **Jeden import zamiast dwóch nazwanych podobnie** — po Sprincie 1 „Dodaj
+   listę" schodzi do roli awaryjnej.
+
+---
+
+## 11. Największe problemy
+
+1. **Produkt nie robi tego, co obiecuje nazwą.** Brak planu tygodnia to nie
+   brakująca funkcja — to brakujący rdzeń, wokół którego wszystko inne miałoby
+   sens.
+2. **Lista zakupów w `localStorage`.** Najlepiej zaprojektowany moduł jest
+   bezużyteczny w scenariuszu, dla którego powstał (plan na laptopie → sklep z
+   telefonem).
+3. **Kontrolki, które kłamią.** Widoczność (P-1, P-2), porcje i czasy (P-3),
+   treść EN (P-4), „Składniki" (P-5), ważność składników (P-6). Każda z nich
+   uczy użytkownika, że interfejsowi nie można ufać.
+4. **Brak pierwszego ekranu z odpowiedzią.** Aplikacja pokazuje bazę danych,
+   zamiast prowadzić.
+5. **Model danych zbudowany przed konsumentem.** Cztery tabele składników i
+   cztery reprezentacje treści przepisu generują koszt utrzymania, nie wartość.
+6. **Rozjazd priorytetów.** Poziom dopracowania warstwy bezpieczeństwa i
+   operacyjnej jest o dwie klasy wyższy niż poziom dopracowania warstwy, dla
+   której użytkownik otwiera aplikację.
+
+---
+
+## 12. Największe zalety
+
+1. **Fundament techniczny jest gotowy na rozwój produktu.** Alembic z liniową
+   historią 7 migracji, 121 testów, rozdzielone produkcja i RC z osobnymi
+   bazami, zweryfikowany backup, runbooki wdrożeniowe i rollbacku. To jest
+   rzadkie w projekcie tej wielkości i to jest realna przewaga.
+2. **Import przepisu z URL to najlepsza funkcja produktu.** Rozwiązuje
+   największe tarcie wejścia (nikt nie przepisuje przepisów ręcznie), ma
+   wzorcowy UX draftu z korektą przez człowieka, dwujęzyczne komunikaty błędów
+   i bezpieczeństwo zrobione porządnie (walidacja URL, pinowanie IP, limity,
+   whitelist typów obrazów).
+3. **Tryb zakupów jest zaprojektowany pod realny kontekst użycia**, a nie pod
+   ekran deweloperski.
+4. **Model wielojęzyczny i model składników są przemyślane** — są przedwczesne
+   względem produktu, ale kiedy nadejdzie ich moment, nie trzeba będzie ich
+   projektować od nowa. To dług, ale dobrze udokumentowany dług z ADR-ami.
+5. **Domena jest ostra i osobista.** Meal Planner nie musi być uniwersalny ani
+   konkurencyjny — musi obsłużyć jedno gospodarstwo domowe. To pozwala odrzucać
+   90% pomysłów bez żalu.
+6. **Produkt ma realnych użytkowników i realne dane** (5 kont, 64 przepisy, 4
+   autorów). Nie jest projektem-szkieletem.
+
+---
+
+## 13. Rekomendacja
+
+Kolejność jest niepodlegająca negocjacji, bo wynika z zależności produktowych,
+nie z preferencji:
+
+1. **Zamknąć wizję** (ten audyt + [North Star](../north-star.md) +
+   [Vision](../product/vision.md)) — Sprint 0.
+2. **Zbudować plan tygodnia i serwerową listę zakupów** — Sprint 1. To jest
+   moment, w którym produkt zaczyna odpowiadać swojej nazwie.
+3. **Dashboard „co dzisiaj?"** — Sprint 2, dopiero gdy jest co pokazywać.
+4. **Kontrakt integracyjny dla MAP** — Sprint 2, na tych samych danych co
+   dashboard.
+5. **Ingredient Engine (Fazy C/D)** — dopiero gdy lista zakupów istnieje po
+   stronie serwera i ma z czego korzystać.
+
+Szczegóły: [roadmapa](../product/roadmap.md) i
+[backlog](../product/backlog.md).
+
+---
+
+## 14. Powiązane dokumenty
+
+- [North Star](../north-star.md) — nowa wizja produktu
+- [Product Vision](../product/vision.md)
+- [Roadmap](../product/roadmap.md) — Sprint 0 i Sprint 1
+- [Backlog](../product/backlog.md)
+- [Portfolio modułów](../modules/README.md)
+- [Propozycja dashboardu](../product/dashboard.md)
+- [Integracja z MAP](../integrations/map.md)
+- [Audyt produkcyjny 2026-08-04](meal-planner-production-audit.md) — warstwa
+  infrastrukturalna, nadal aktualna jako opis środowiska
+- [Ingredients Feature Review](ingredients-feature-review.md)

--- a/docs/decisions/ADR-001.md
+++ b/docs/decisions/ADR-001.md
@@ -1,0 +1,67 @@
+---
+id: ADR-001
+title: Plan posiłków ma jeden slot dziennie w v1
+status: Accepted
+date: 2026-08-07
+area: Produkt, model planu
+summary: Wersja pierwsza planu obsługuje jeden posiłek dziennie (obiad); śniadania, kolacje i przekąski nie wchodzą do v1.
+---
+
+# ADR-001
+
+## Status
+
+Accepted
+
+## Kontekst
+
+Model planu posiłków nie istnieje i powstaje w Sprincie 1. Pierwsza decyzja,
+jaka musi zapaść, to ile posiłków dziennie plan obsługuje, bo od tego zależy
+kształt tabeli, ekran planu tygodnia i złożoność generowania listy zakupów.
+
+Produkt konkuruje z kartką i pamięcią. Przegrywa nie brakiem opcji, tylko
+liczbą kliknięć potrzebnych do zaplanowania tygodnia. Siatka 7 × 3 to 21 pól do
+wypełnienia w niedzielny wieczór — to jest projekt, który zostanie porzucony po
+dwóch tygodniach.
+
+## Decyzja
+
+Plan v1 obsługuje **jeden slot posiłkowy dziennie — obiad**.
+
+Slot nie jest osobną encją. Wpis planu to relacja `data → przepis albo tekst`,
+z co najwyżej jednym wpisem na dzień.
+
+Wpis może być pusty albo tekstowy („obiad u rodziców", „zostało z wczoraj") —
+plan przyjmujący wyłącznie przepisy z katalogu nie przetrwa zderzenia z
+rzeczywistością.
+
+## Konsekwencje
+
+- Ekran planu tygodnia to siedem pól, nie siatka 7 × 3.
+- Generowanie listy zakupów agreguje maksymalnie siedem przepisów tygodniowo.
+- Dashboard ma jednoznaczną odpowiedź na pytanie „co dziś" — nie musi wybierać
+  między trzema posiłkami ani znać pory dnia.
+- Śniadania, kolacje i przekąski **nie są obsługiwane**. Użytkownik, który ich
+  potrzebuje, wpisuje tekst albo czeka.
+- Rozszerzenie do wielu slotów wymaga dodania kolumny `slot` z wartością
+  domyślną i migracji, która przypisze istniejące wpisy do slotu „obiad".
+  Droga jest otwarta i tania; droga odwrotna (odchudzanie modelu 7 × 3) nie
+  jest.
+
+## Alternatywy
+
+- **Trzy sloty od razu (śniadanie/obiad/kolacja)** — odrzucone: potraja
+  powierzchnię UI, listy zakupów i dashboardu, zanim ktokolwiek udowodnił, że
+  plan jest w ogóle używany.
+- **Dowolna liczba posiłków na dzień** — odrzucone: brak ograniczenia to brak
+  decyzji; przerzuca projektowanie modelu na użytkownika.
+
+## Data
+
+2026-08-07
+
+## Powiązane moduły
+
+- meal-plan
+- shopping-list
+- dashboard

--- a/docs/decisions/ADR-002.md
+++ b/docs/decisions/ADR-002.md
@@ -1,0 +1,71 @@
+---
+id: ADR-002
+title: Plan i lista zakupów należą do gospodarstwa domowego, nie do użytkownika
+status: Accepted
+date: 2026-08-07
+area: Produkt, model danych, dostęp
+summary: Instancja Meal Plannera obsługuje jedno gospodarstwo domowe; istnieje jeden wspólny plan i jedna wspólna lista zakupów, bez planów per użytkownik i bez multi-tenancy.
+---
+
+# ADR-002
+
+## Status
+
+Accepted
+
+## Kontekst
+
+Dzisiejszy model danych zna użytkownika (`Recipe.user_id`) i flagę widoczności
+(`is_public`), ale nie zna pojęcia gospodarstwa domowego. Plan posiłków i lista
+zakupów to byty, które w realnym użyciu są wspólne: jedna osoba planuje, druga
+robi zakupy, obie patrzą na to samo.
+
+Gdyby plan był prywatny per użytkownik, produkt rozwiązywałby problem jednej
+osoby i tworzyłby nowy problem — synchronizację między domownikami.
+
+## Decyzja
+
+**Instancja Meal Plannera obsługuje dokładnie jedno gospodarstwo domowe.**
+
+Istnieje jeden wspólny plan posiłków i jedna wspólna lista zakupów. Każdy
+zalogowany użytkownik widzi i edytuje ten sam plan i tę samą listę.
+
+Nie wprowadzamy encji „gospodarstwo domowe" ani mechanizmów multi-tenancy.
+Granicą gospodarstwa jest granica instancji.
+
+Autorstwo przepisów pozostaje bez zmian — `Recipe.user_id` i `is_public` to
+osobna oś (kto dodał przepis), niezależna od planu.
+
+## Konsekwencje
+
+- Tabele planu i listy zakupów nie mają właściciela w sensie dostępu; mają co
+  najwyżej `created_by` / `updated_by` do audytu i do pokazania „kto to dodał".
+- Nie budujemy zapraszania do gospodarstwa, ról domowych ani współdzielenia —
+  to byłoby budowanie SaaS-a bez potrzeby.
+- Dwie osoby edytujące plan jednocześnie mogą się nadpisać. W v1 obowiązuje
+  „ostatni zapis wygrywa"; przy skali jednego domu to akceptowalne. Blokowanie
+  optymistyczne wchodzi dopiero, jeśli zacznie boleć.
+- Flagę `is_public` przy przepisach można docelowo uprościć do „mój / wspólny",
+  bo „publiczny" w obrębie jednego domu znaczy „wspólny". To osobna zmiana, nie
+  część tej decyzji.
+- Gdyby kiedykolwiek pojawiła się potrzeba obsługi wielu domów, właściwą
+  odpowiedzią jest osobna instancja albo nowa decyzja unieważniająca tę —
+  nie doklejenie multi-tenancy do istniejącego modelu.
+
+## Alternatywy
+
+- **Plan prywatny per użytkownik, z opcjonalnym udostępnianiem** — odrzucone:
+  rozwiązuje problem, którego nie mamy, i tworzy problem synchronizacji, który
+  jest realny.
+- **Pełny model gospodarstw domowych z zapraszaniem i rolami** — odrzucone:
+  koszt multi-tenancy bez wartości dla jednego domu.
+
+## Data
+
+2026-08-07
+
+## Powiązane moduły
+
+- meal-plan
+- shopping-list
+- identity

--- a/docs/decisions/ADR-003.md
+++ b/docs/decisions/ADR-003.md
@@ -1,0 +1,80 @@
+---
+id: ADR-003
+title: Lista zakupów sumuje wyłącznie identyczny składnik przy zgodnej jednostce
+status: Accepted
+date: 2026-08-07
+area: Produkt, lista zakupów
+summary: Pozycje listy łączą się tylko przy zgodnej nazwie i zgodnej jednostce; różne jednostki dają osobne pozycje, bez tabeli konwersji i bez scalania aliasów w v1.
+---
+
+# ADR-003
+
+## Status
+
+Accepted
+
+## Kontekst
+
+Obecna lista zakupów bierze całą linię składnika jako nazwę pozycji i zwiększa
+licznik o 1 przy powtórzeniu, więc „2 łyżki oliwy" z licznikiem 2 znaczy „dwa
+razy dwie łyżki". To nie jest niedokładność — to jest wynik, który wprowadza w
+błąd (P-7 w [audycie produktowym](../audits/product-audit-2026-08-07.md)).
+
+Generowanie listy z planu wymaga rozstrzygnięcia, kiedy dwie pozycje z różnych
+przepisów to ta sama pozycja. Pełna normalizacja jednostek wymagałaby tabeli
+konwersji, gęstości produktów i słownika aliasów — czyli całego Ingredient
+Engine w Sprincie 1.
+
+## Decyzja
+
+Pozycje listy zakupów sumują się **wyłącznie wtedy, gdy zgadza się
+znormalizowana nazwa składnika I jednostka**.
+
+- `2 × łyżka oliwy` + `1 × łyżka oliwy` = **3 łyżki oliwy**
+- `100 ml oliwy` + `2 łyżki oliwy` = **dwie osobne pozycje**
+
+Normalizacja nazwy w v1 to przycięcie białych znaków i porównanie bez
+wielkości liter — **dokładne dopasowanie**. Aliasy („pomidor" / „pomidory")
+**nie są** scalane.
+
+Brak jednostki jest traktowany jako osobna, pełnoprawna jednostka („bez
+jednostki"), nie jako wartość pusta pasująca do wszystkiego.
+
+## Konsekwencje
+
+- Lista może zawierać dwie pozycje tego samego produktu w różnych jednostkach.
+  To jest świadomy wybór: **lepiej pokazać dwie pozycje prawdziwe niż jedną
+  zmyśloną**.
+- Sprint 1 nie potrzebuje tabeli konwersji jednostek, gęstości ani Ingredient
+  Engine. To jest główny powód tej decyzji.
+- Każda pozycja listy pamięta, z których przepisów pochodzi — użytkownik musi
+  móc odpowiedzieć sobie na pytanie „skąd to się wzięło" i dlaczego są dwie
+  pozycje oliwy.
+- 64 istniejące przepisy nie mają strukturalnych składników, więc dla nich
+  agregacja nie zadziała i pozycje trafią na listę jako surowy tekst z
+  ilością 1. Jest to akceptowalne przejściowo i jest głównym uzasadnieniem
+  backfillu z [backlogu](../product/backlog.md).
+- Scalanie aliasów i sortowanie po działach sklepu wchodzą razem z Ingredient
+  Engine i będą wymagały zmiany tej decyzji albo jej rozszerzenia — wtedy
+  powstanie nowy ADR.
+
+## Alternatywy
+
+- **Pełna normalizacja jednostek z konwersją (ml ↔ łyżka ↔ g)** — odrzucone:
+  wymaga gęstości per produkt, jest źródłem cichych błędów („2 łyżki mąki" ≠
+  „2 łyżki miodu" w gramach) i przenosi Ingredient Engine do Sprintu 1.
+- **Sumowanie po samej nazwie, z pominięciem jednostki** — odrzucone: produkuje
+  liczby, które nic nie znaczą; to jest dokładnie dzisiejszy błąd, tylko lepiej
+  ukryty.
+- **Brak agregacji, lista jako płaski zrzut linii składników** — odrzucone:
+  przerzuca pracę scalania z powrotem na użytkownika w sklepie.
+
+## Data
+
+2026-08-07
+
+## Powiązane moduły
+
+- shopping-list
+- meal-plan
+- ingredients

--- a/docs/decisions/ADR-004.md
+++ b/docs/decisions/ADR-004.md
@@ -1,0 +1,80 @@
+---
+id: ADR-004
+title: Porcje i czasy są utrwalane w modelu przepisu
+status: Accepted
+date: 2026-08-07
+area: Produkt, model przepisu, import
+summary: Recipe zyskuje servings, prep_time_minutes i cook_time_minutes; importer je zapisuje zamiast wyrzucać, a total_time znika z formularza zatwierdzania.
+---
+
+# ADR-004
+
+## Status
+
+Accepted
+
+## Kontekst
+
+Formularz draftu importu zbiera od użytkownika „Porcje", „Czas przygotowania" i
+„Czas gotowania". Schemat `RecipeImportConfirmRequest` te pola waliduje, ale
+`create_recipe_from_import()` ich nie zapisuje, bo model `Recipe` nie ma takich
+kolumn. Użytkownik wpisuje dane, klika „Zapisz przepis" i traci je bez
+ostrzeżenia (P-3 w [audycie produktowym](../audits/product-audit-2026-08-07.md)).
+
+Parser schema.org już te wartości odczytuje ze strony źródłowej, więc dane są
+dostępne za darmo. Stan pośredni — zbieramy i wyrzucamy — jest gorszy niż
+którakolwiek z jawnych opcji.
+
+## Decyzja
+
+Model `Recipe` zyskuje trzy kolumny:
+
+- `servings` — **tekst**, nie liczba (źródła podają „4 porcje", „4-6
+  servings", „2 duże"); parsowanie na liczbę to osobny problem, rozwiązywany
+  dopiero przy skalowaniu porcji,
+- `prep_time_minutes` — liczba całkowita, nullable,
+- `cook_time_minutes` — liczba całkowita, nullable.
+
+`total_time` **nie jest przechowywany** i **znika z kontraktu `confirm`**.
+Formularz go nie pokazuje, więc nie wolno go przyjmować — inaczej odtwarzamy
+ten sam problem w mniejszej skali. Podgląd (`preview`) może go nadal
+raportować jako informację.
+
+Te same trzy pola trafiają do formularza ręcznego dodawania i edycji przepisu —
+przepis dodany ręcznie nie może być uboższy niż zaimportowany.
+
+## Konsekwencje
+
+- Wymagana migracja Alembic dodająca trzy kolumny nullable. Nie łamie żadnego
+  istniejącego przepisu (64 przepisy dostają `NULL`).
+- P-3 zostaje zamknięte: import przestaje wyrzucać dane użytkownika.
+- Dashboard może pokazać „45 min · 4 porcje" pod nazwą dania — to jest
+  informacja, która realnie wpływa na wybór posiłku na dziś.
+- Skalowanie porcji z [backlogu](../product/backlog.md) dostaje podstawę
+  danych. Sama funkcja nie wchodzi teraz.
+- `servings` jako tekst oznacza, że nie da się na nim liczyć bez późniejszego
+  parsowania. Jest to świadomy koszt — alternatywą byłoby odrzucanie połowy
+  wartości ze źródeł.
+- Migracja wchodzi w te same tabele, które właśnie dostały siedem migracji na
+  branchu `feature/i18n-recipe-import-ingredients`; kolejność wdrożenia musi
+  być ustalona po przyjęciu tamtego brancha, nie równolegle.
+
+## Alternatywy
+
+- **Usunąć pola z formularza importu** — odrzucone: dane są dostępne za darmo z
+  parsera, a czas przygotowania jest jednym z realnych kryteriów wyboru
+  posiłku na dany dzień.
+- **Zostawić stan obecny** — odrzucone: produkt nie może przyjmować danych,
+  których nie zapisuje.
+- **`servings` jako liczba całkowita** — odrzucone: wymusiłoby odrzucanie albo
+  zgadywanie przy „4-6 porcji", co jest cichą utratą informacji.
+
+## Data
+
+2026-08-07
+
+## Powiązane moduły
+
+- recipes
+- recipe-import
+- dashboard

--- a/docs/decisions/ADR-005.md
+++ b/docs/decisions/ADR-005.md
@@ -1,0 +1,102 @@
+---
+id: ADR-005
+title: Integracja z MAP jest kontraktem read-only w wersji 1
+status: Accepted
+date: 2026-08-07
+area: Produkt, integracje, granice systemów
+summary: MAP widzi Meal Plannera przez jeden wersjonowany endpoint podsumowania, uwierzytelniony osobnym tokenem serwisowym; w v1 nie ma żadnych operacji zapisu, współdzielonej sesji ani replikacji danych.
+---
+
+# ADR-005
+
+## Status
+
+Accepted
+
+## Kontekst
+
+MAP jest pierwszym miejscem otwieranym rano; Meal Planner jest otwierany dwa
+razy w tygodniu. Bez integracji odpowiedź na pytanie „co dziś na obiad" wymaga
+przełączenia aplikacji — czyli dokładnie tego tarcia, które MAP ma usuwać.
+
+Jednocześnie Meal Planner jest osobnym produktem z własnym repozytorium,
+deploymentem, logowaniem i roadmapą. Po stronie MAP zapisano to jako ADR-001
+(Meal Planner pozostaje osobnym systemem) i ADR-007 (MAP integruje, nie
+wchłania). Bez jawnego kontraktu każda kolejna potrzeba MAP kończyłaby się
+sięgnięciem po bazę, sesję albo skopiowaniem danych — i po kilku takich krokach
+Meal Planner przestałby być osobnym produktem, nie podejmując nigdy takiej
+decyzji.
+
+## Decyzja
+
+Integracja z MAP odbywa się wyłącznie przez **jeden wersjonowany kontrakt
+HTTP**, w wersji 1 **całkowicie do odczytu**.
+
+1. **Jeden endpoint podsumowania** — `GET /api/v1/integration/summary`,
+   zwracający znormalizowany obiekt z polem `contract_version`.
+2. **Osobny token serwisowy** przekazywany nagłówkiem, niezależny od sesji
+   użytkownika i cookie `access_token`, o jednym zakresie: odczyt tego
+   endpointu.
+3. **Brak współdzielonego logowania i sesji.** Meal Planner zachowuje własną
+   tożsamość i własną tabelę `users`; MAP nie loguje do niego użytkownika i
+   nie wystawia SSO.
+4. **Brak replikacji danych.** MAP może cache'ować odpowiedź z krótkim TTL i
+   jawnym znacznikiem czasu; nie prowadzi własnej bazy przepisów, planu ani
+   listy zakupów.
+5. **Brak operacji zapisu z MAP w v1.** Fail closed: brak tokena, zły token
+   lub brak danych zwraca błąd, nigdy dane częściowe udające pełne.
+6. **MAP korzysta z podsumowania i deep-linków** (`/plan?date=…`, `/plan`,
+   `/shopping`) i **nie przejmuje logiki Meal Plannera** — w szczególności nie
+   planuje posiłków.
+
+Zależność jest jednostronna: MAP zna Meal Plannera, Meal Planner nie wie o
+istnieniu MAP. Wyłączenie MAP nie może wpłynąć na działanie Meal Plannera.
+
+Pełny kształt kontraktu — zakres pól, przykładowa odpowiedź, lista dziesięciu
+rzeczy, których MAP nie robi, oraz warunki ewentualnej wersji 2 — mieszka w
+[integrations/map.md](../integrations/map.md). Ten ADR jest zapisem decyzji, nie
+drugą kopią kontraktu.
+
+## Konsekwencje
+
+- Meal Planner musi dostarczyć endpoint, token serwisowy i deep-linki. To
+  zadanie Sprintu 2, po tym jak Sprint 1 dostarczy plan i serwerową listę
+  zakupów — wcześniej kontrakt zwracałby wyłącznie liczbę przepisów.
+- `contract_version` obowiązuje od pierwszego wdrożenia. Zmiana łamiąca
+  kontrakt wymaga nowej wersji, nie modyfikacji istniejącej — inaczej zmiana w
+  Meal Plannerze psuje pulpit MAP.
+- MAP musi umieć wyrenderować pulpit przy każdym polu nieobecnym lub `null`.
+  Niedostępność Meal Plannera jest pustym kafelkiem, nie awarią MAP.
+- Brak zapisu w v1 oznacza, że „kup mleko" zapisane rano w MAP nadal wymaga
+  wejścia do Meal Plannera. Akceptujemy to tarcie świadomie: zapis przez
+  integrację tworzy drugie źródło prawdy dla tego samego stanu, zanim
+  ktokolwiek udowodnił, że kontrakt read-only jest w ogóle używany.
+- Zamyka zależność „kontrakt statusu po stronie Meal Plannera" z backlogu MAP
+  — po stronie Meal Plannera ma ona teraz właściciela, kształt i status.
+- Rozszerzenie o wersję 2 (dwie wąskie akcje zapisu) wymaga nowego ADR-a i
+  dowodu, że v1 jest używana. Nie jest to decyzja implementacyjna.
+
+## Alternatywy
+
+- **Wspólna baza albo bezpośredni odczyt PostgreSQL przez MAP** — odrzucone:
+  najtańsze dziś, najdroższe potem; wiąże cykle wydań dwóch produktów i łamie
+  ADR-001 po stronie MAP.
+- **Współdzielona sesja / SSO od razu** — odrzucone: wprowadza wspólną
+  tożsamość, zanim istnieje potrzeba zapisu, i czyni Meal Plannera zależnym od
+  dostępności MAP przy logowaniu.
+- **Kilka endpointów tematycznych zamiast jednego podsumowania** — odrzucone:
+  wielokrotnie zwiększa powierzchnię kontraktu i zachęca MAP do składania
+  własnego widoku danych zamiast pokazywania decyzji (ADR-005 po stronie MAP).
+- **Zapis z MAP już w v1** — odrzucone: podwaja powierzchnię błędów bez dowodu
+  wartości; przesunięte do warunkowej wersji 2.
+
+## Data
+
+2026-08-07
+
+## Powiązane moduły
+
+- integrations/map
+- meal-plan
+- shopping-list
+- dashboard

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -15,9 +15,11 @@ obowiązywać, dostaje status `Superseded` i wskazanie następcy.
 | [ADR-002](ADR-002.md) | Plan i lista zakupów należą do gospodarstwa domowego, nie do użytkownika | Accepted | 2026-08-07 | Produkt, model danych, dostęp |
 | [ADR-003](ADR-003.md) | Lista zakupów sumuje wyłącznie identyczny składnik przy zgodnej jednostce | Accepted | 2026-08-07 | Produkt, lista zakupów |
 | [ADR-004](ADR-004.md) | Porcje i czasy są utrwalane w modelu przepisu | Accepted | 2026-08-07 | Produkt, model przepisu, import |
+| [ADR-005](ADR-005.md) | Integracja z MAP jest kontraktem read-only w wersji 1 | Accepted | 2026-08-07 | Produkt, integracje, granice systemów |
 
 ADR-001 … ADR-004 to cztery decyzje odblokowujące Sprint 1, podjęte przy
-przeglądzie Sprintu 0. Ich kontekst opisuje
+przeglądzie Sprintu 0. ADR-005 zamyka piąty deliverable Sprintu 0 — granice
+wobec MAP. Kontekst opisuje
 [audyt produktowy](../audits/product-audit-2026-08-07.md), a skutki są
 odzwierciedlone w [roadmapie](../product/roadmap.md) i dokumentach modułów.
 
@@ -32,9 +34,11 @@ wprowadzenia numeracji ADR:
 - `docs/decisions/ingredient-normalization.md` — zakres normalizacji
   składników i sekcje sklepowe w V1
 
-Przy przyjmowaniu tamtego brancha należy je przenumerować na **ADR-005** i
-**ADR-006**, uzupełnić o frontmatter zgodny z pozostałymi i dopisać do tabeli
-powyżej. Do tego czasu ten katalog nie jest kompletnym rejestrem decyzji
+Przy przyjmowaniu tamtego brancha należy je przenumerować na **ADR-006** i
+**ADR-007**, uzupełnić o frontmatter zgodny z pozostałymi i dopisać do tabeli
+powyżej. Numeracja idzie według daty przyjęcia decyzji, a nie według daty
+powstania dokumentu — dlatego numery 006/007, mimo że decyzje zapadły
+wcześniej. Do tego czasu ten katalog nie jest kompletnym rejestrem decyzji
 projektu.
 
 ## Zasady

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,49 @@
+---
+status: Active
+last_updated: 2026-08-07
+---
+
+# Decyzje architektoniczne i produktowe
+
+Każda ważna decyzja produktowa lub architektoniczna dostaje dokument w tym
+katalogu. Decyzja raz zapisana nie jest usuwana — jeżeli przestaje
+obowiązywać, dostaje status `Superseded` i wskazanie następcy.
+
+| ID | Tytuł | Status | Data | Obszar |
+|---|---|---|---|---|
+| [ADR-001](ADR-001.md) | Plan posiłków ma jeden slot dziennie w v1 | Accepted | 2026-08-07 | Produkt, model planu |
+| [ADR-002](ADR-002.md) | Plan i lista zakupów należą do gospodarstwa domowego, nie do użytkownika | Accepted | 2026-08-07 | Produkt, model danych, dostęp |
+| [ADR-003](ADR-003.md) | Lista zakupów sumuje wyłącznie identyczny składnik przy zgodnej jednostce | Accepted | 2026-08-07 | Produkt, lista zakupów |
+| [ADR-004](ADR-004.md) | Porcje i czasy są utrwalane w modelu przepisu | Accepted | 2026-08-07 | Produkt, model przepisu, import |
+
+ADR-001 … ADR-004 to cztery decyzje odblokowujące Sprint 1, podjęte przy
+przeglądzie Sprintu 0. Ich kontekst opisuje
+[audyt produktowy](../audits/product-audit-2026-08-07.md), a skutki są
+odzwierciedlone w [roadmapie](../product/roadmap.md) i dokumentach modułów.
+
+## Decyzje spoza tego baseline'u
+
+Dwie wcześniejsze decyzje istnieją na branchu
+`feature/i18n-recipe-import-ingredients` pod nazwami opisowymi, sprzed
+wprowadzenia numeracji ADR:
+
+- `docs/decisions/recipe-translations.md` — model treści wielojęzycznej
+  (Wariant B: osobna tabela `recipe_translations`)
+- `docs/decisions/ingredient-normalization.md` — zakres normalizacji
+  składników i sekcje sklepowe w V1
+
+Przy przyjmowaniu tamtego brancha należy je przenumerować na **ADR-005** i
+**ADR-006**, uzupełnić o frontmatter zgodny z pozostałymi i dopisać do tabeli
+powyżej. Do tego czasu ten katalog nie jest kompletnym rejestrem decyzji
+projektu.
+
+## Zasady
+
+1. Nowa ważna decyzja produktowa lub architektoniczna = nowy ADR w tym samym
+   commicie, w którym zapada.
+2. ADR opisuje kontekst, decyzję, konsekwencje i odrzucone alternatywy —
+   szczególnie konsekwencje negatywne, bo to one są powodem, dla którego
+   wracamy do decyzji.
+3. Numeracja jest ciągła i nigdy nie jest używana ponownie.
+4. Zmiana decyzji nie polega na edycji starego ADR-a, tylko na nowym ADR-ze ze
+   statusem `Accepted` i oznaczeniu poprzedniego jako `Superseded by ADR-NNN`.

--- a/docs/integrations/map.md
+++ b/docs/integrations/map.md
@@ -1,0 +1,216 @@
+---
+status: Proposed — kontrakt do zatwierdzenia w Sprincie 0, implementacja w Sprincie 2
+last_updated: 2026-08-07
+---
+
+# Integracja z MAP
+
+## Zasada nadrzędna
+
+**Meal Planner pozostaje osobnym produktem. Nie zostaje wchłonięty.**
+
+Osobne repozytorium, osobny deployment, osobne logowanie, osobna baza, osobna
+roadmapa, osobny cykl wydań. Ta zasada jest zapisana po obu stronach: w
+[North Star Meal Plannera](../north-star.md) oraz w MAP jako ADR-001
+(„Meal Planner pozostaje osobnym systemem") i ADR-007 („MAP integruje, nie
+wchłania").
+
+Integracja odbywa się wyłącznie przez **jeden wersjonowany kontrakt HTTP**.
+Nie przez wspólną bazę, nie przez wspólną sesję, nie przez współdzielony kod,
+nie przez kopiowanie danych.
+
+Kierunek zależności jest jednostronny: **MAP zna Meal Plannera. Meal Planner
+nie wie o istnieniu MAP.** Meal Planner wystawia kontrakt i nic nie zakłada o
+jego konsumencie. Wyłączenie MAP nie może w żaden sposób wpłynąć na działanie
+Meal Plannera.
+
+## Po co ta integracja istnieje
+
+MAP jest pierwszym miejscem otwieranym rano. Meal Planner jest otwierany dwa
+razy w tygodniu. Bez integracji odpowiedź na pytanie „co dziś na obiad" wymaga
+przełączenia aplikacji — czyli dokładnie tego tarcia, które MAP ma usuwać
+(cel 2 North Star MAP: oszczędność czasu; cel 3: integracja projektów).
+
+Wartość integracji dla Meal Plannera jest odwrotna: plan zaczyna być widoczny
+w miejscu, w którym użytkownik i tak patrzy, więc plan zaczyna być używany.
+
+## 1. Jakie informacje MAP powinien widzieć
+
+MAP dostaje **decyzje, nie surowe dane** (ADR-005 po stronie MAP). Każde pole
+poniżej odpowiada na pytanie, które użytkownik zadaje rano, patrząc na pulpit.
+
+| Informacja | Po co | Odpowiada na |
+|---|---|---|
+| **Posiłek na dziś** — nazwa, `recipe_id`, deep-link | Główna wartość integracji | „Co jemy dziś?" |
+| **Posiłek na jutro** — nazwa, deep-link | Pozwala zareagować z wyprzedzeniem (rozmrożenie, dokupienie) | „Czy muszę coś dziś przygotować?" |
+| **Kompletność planu bieżącego tygodnia** — zaplanowane dni / wszystkie dni, lista luk | Sygnał, że trzeba usiąść do planowania | „Czy plan jest domknięty?" |
+| **Liczba pozycji do kupienia** (nieodhaczonych) + deep-link do listy | Decyzja „czy po drodze wpaść do sklepu" | „Czy trzeba zrobić zakupy?" |
+| **Sygnały wymagające uwagi** — znormalizowana lista `{code, severity, message_key}` (np. `week_incomplete`, `shopping_list_empty_but_plan_exists`) | Pulpit MAP pokazuje powód, nie każe interpretować liczb | „Co zasługuje na uwagę?" |
+| **Status instancji** — nazwa aplikacji, wersja, środowisko, czas wygenerowania odpowiedzi | Health w portfolio projektów MAP | „Czy Meal Planner działa?" |
+| **Agregaty katalogu** — liczba przepisów, ewentualnie liczba zaimportowanych | Dowód życia projektu w portfolio/Hire Me | „Czy projekt żyje?" |
+
+Czego MAP **nie** dostaje:
+
+- treści przepisów (nazwy poza dzisiejszym i jutrzejszym posiłkiem, opisów,
+  instrukcji, składników, zdjęć),
+- zawartości listy zakupów pozycja po pozycji,
+- danych użytkowników, ról, logów logowania ani logów requestów,
+- historii planów i historii zakupów.
+
+Reguła: **MAP dostaje liczniki, jedną nazwę dania i linki. Wszystko, co
+wymaga przeglądania, wymaga wejścia do Meal Plannera.**
+
+## 2. Kształt kontraktu
+
+Jeden endpoint, jeden znormalizowany obiekt wyniku (ADR-003 po stronie MAP):
+
+```
+GET /api/v1/integration/summary
+Authorization: Bearer <service token>
+```
+
+```jsonc
+{
+  "contract_version": "1.0",
+  "generated_at": "2026-08-07T06:30:00Z",
+  "app": {
+    "name": "meal-planner",
+    "instance": "production",
+    "version": "1.4.0",
+    "healthy": true
+  },
+  "today": {
+    "date": "2026-08-07",
+    "meal": { "recipe_id": 42, "name": "Kurczak z warzywami", "url": "https://meal.maciak.online/plan?date=2026-08-07" }
+  },
+  "tomorrow": {
+    "date": "2026-08-08",
+    "meal": null
+  },
+  "week": {
+    "start": "2026-08-03",
+    "planned_days": 4,
+    "total_days": 7,
+    "url": "https://meal.maciak.online/plan"
+  },
+  "shopping": {
+    "open_items": 12,
+    "done_items": 5,
+    "url": "https://meal.maciak.online/shopping"
+  },
+  "attention": [
+    { "code": "week_incomplete", "severity": "info", "context": { "missing_days": 3 } }
+  ],
+  "stats": { "recipes_total": 64 }
+}
+```
+
+Zasady kontraktu:
+
+- **Wersjonowany od pierwszego dnia** (`contract_version`). Zmiana łamiąca
+  kontrakt wymaga nowej wersji, nie modyfikacji istniejącej — inaczej zmiana w
+  Meal Plannerze psuje pulpit MAP.
+- **Wszystkie pola opcjonalne z punktu widzenia konsumenta.** MAP musi umieć
+  wyrenderować pulpit, gdy `today.meal` jest `null` albo gdy całej sekcji brak.
+- **Kody, nie zdania.** `attention[].code` jest maszynowy; tłumaczenie na tekst
+  należy do MAP. Meal Planner nie narzuca języka pulpitu MAP.
+- **Bez PII.** W odpowiedzi nie ma nazw użytkowników, adresów IP ani niczego,
+  co identyfikuje osobę.
+- **Read-only, idempotentne, cache'owalne.** Wywołanie kontraktu niczego nie
+  zmienia.
+
+Uwierzytelnienie: **osobny token serwisowy** przekazywany nagłówkiem, całkowicie
+niezależny od sesji użytkownika i cookie `access_token`. Token ma jeden zakres:
+odczyt tego jednego endpointu. Brak tokena, zły token, brak danych → **fail
+closed**: `401`/`503`, nigdy dane częściowe udające pełne.
+
+Degradacja po stronie MAP: błąd lub timeout oznacza kafelek „brak danych z Meal
+Plannera", nigdy mock prezentowany jako prawda.
+
+## 3. Jakie akcje MAP powinien móc wykonać
+
+### Wersja 1 — zero akcji zapisu
+
+Kontrakt v1 jest **wyłącznie do odczytu**. Jedyne „akcje" MAP to **deep-linki**
+otwierające Meal Plannera w odpowiednim miejscu:
+
+| Akcja w MAP | Efekt |
+|---|---|
+| „Zobacz dzisiejszy posiłek" | `…/plan?date=YYYY-MM-DD` |
+| „Otwórz plan tygodnia" | `…/plan` |
+| „Otwórz listę zakupów" | `…/shopping` |
+
+To jest świadomy wybór, nie ograniczenie techniczne. Zapis przez integrację
+tworzy dwa źródła prawdy dla tego samego stanu i podwaja powierzchnię błędów,
+zanim ktokolwiek udowodnił, że kontrakt read-only jest w ogóle używany.
+
+### Wersja 2 — dokładnie dwie akcje, po udowodnieniu wartości v1
+
+| Akcja | Endpoint | Dlaczego akurat ta |
+|---|---|---|
+| Dodaj pozycję do listy zakupów | `POST /api/v1/integration/shopping-items` | MAP jest miejscem, gdzie rano zapisuje się „kup mleko"; przełączanie aplikacji dla jednej pozycji to dokładnie to tarcie, które integracja ma usuwać |
+| Oznacz dzisiejszy posiłek jako ugotowany | `POST /api/v1/integration/today/cooked` | Jedno kliknięcie zamyka pętlę dnia i zasila przyszłą historię |
+
+Warunki dla obu: wąski zakres tokena (osobny od read-only), idempotencja
+(klucz idempotencji w żądaniu), limit tempa, pełny audyt po stronie Meal
+Plannera, i **żadnych innych akcji**. Rozszerzanie tej listy wymaga decyzji
+produktowej, nie decyzji implementacyjnej.
+
+## 4. Czego MAP nie powinien robić
+
+Lista jest twarda i jest częścią kontraktu:
+
+1. **Nie replikuje danych Meal Plannera.** Żadnej kopii przepisów, planu ani
+   listy zakupów po stronie MAP. Cache odpowiedzi kontraktu — tak, z krótkim
+   TTL i jawnym znacznikiem czasu. Własna baza danych domenowych — nie.
+2. **Nie renderuje UI Meal Plannera.** Bez iframe'ów, bez odtwarzania listy
+   przepisów, bez formularzy edycji. MAP pokazuje kafelek i link.
+3. **Nie planuje posiłków.** Planowanie jest rdzeniem Meal Plannera. W dniu, w
+   którym MAP zacznie planować, przestaje integrować i zaczyna wchłaniać.
+4. **Nie edytuje ani nie usuwa przepisów, planów i pozycji listy.** W v1 nie
+   pisze nic; w v2 wyłącznie dwie akcje wymienione wyżej.
+5. **Nie dotyka bazy Meal Plannera.** Żadnego wspólnego PostgreSQL, żadnego
+   czytania `fastapi_db` z zewnątrz, żadnego SQL przez granicę systemów.
+   Wyłącznie HTTP.
+6. **Nie współdzieli sesji ani tożsamości.** Meal Planner ma własne logowanie i
+   własną tabelę `users`. MAP nie loguje użytkownika do Meal Plannera, nie
+   wystawia SSO i nie zarządza kontami Meal Plannera.
+7. **Nie wystawia danych Meal Plannera publicznie.** Publiczna część MAP
+   (Hire Me, konto demo) może zobaczyć co najwyżej anonimowe agregaty
+   („projekt żyje: N przepisów") — nigdy dzisiejszego posiłku ani listy
+   zakupów.
+8. **Nie wymusza wspólnego stosu technologicznego, repozytorium, harmonogramu
+   wydań ani wspólnego deploymentu.** Meal Planner może zmienić framework,
+   bazę i hosting bez pytania MAP o zgodę — o ile kontrakt pozostaje spełniony.
+9. **Nie traktuje niedostępności Meal Plannera jako awarii MAP.** Brak
+   odpowiedzi to pusty kafelek, nie błąd pulpitu.
+10. **Nie definiuje roadmapy Meal Plannera.** Potrzeba MAP może być zgłoszona
+    jako pozycja w backlogu Meal Plannera i przechodzi ten sam test North Star
+    co każda inna.
+
+## 5. Warunki wejścia i kolejność
+
+Integracja **nie ma sensu przed** [planem posiłków](../modules/meal-plan.md) i
+[serwerową listą zakupów](../modules/shopping-list.md) — bez nich kontrakt
+zwróciłby wyłącznie liczbę przepisów, a to nie jest odpowiedź na żadne pytanie
+z pulpitu MAP.
+
+Kolejność:
+
+1. **Sprint 0** — zatwierdzenie tego dokumentu jako deklaracji kontraktu;
+   zgłoszenie do backlogu MAP, że zależność „kontrakt statusu po stronie Meal
+   Plannera" ma właściciela i kształt.
+2. **Sprint 1** — powstaje plan i serwerowa lista zakupów, czyli dane, które
+   kontrakt ma wystawić.
+3. **Sprint 2** — implementacja `GET /api/v1/integration/summary`, token
+   serwisowy, deep-linki, kafelek po stronie MAP.
+4. **Później** — v2 z dwiema akcjami zapisu, jeżeli v1 udowodni, że jest
+   używana.
+
+## Source Of Truth
+
+- Kierunek Meal Plannera: [North Star](../north-star.md)
+- Plan wdrożenia: [roadmapa](../product/roadmap.md)
+- Po stronie MAP: `MAP/docs/ecosystem.md`, `MAP/docs/decisions/ADR-001.md`,
+  `ADR-003.md`, `ADR-005.md`, `ADR-007.md`, pozycja „Obszar Integrations — Meal
+  Planner w MAP" w `MAP/docs/product/backlog.md`

--- a/docs/integrations/map.md
+++ b/docs/integrations/map.md
@@ -1,9 +1,12 @@
 ---
-status: Proposed — kontrakt do zatwierdzenia w Sprincie 0, implementacja w Sprincie 2
+status: Accepted — kontrakt v1 zatwierdzony 2026-08-07, implementacja w Sprincie 2
 last_updated: 2026-08-07
 ---
 
 # Integracja z MAP
+
+Decyzja: [ADR-005](../decisions/ADR-005.md). Ten dokument jest kształtem
+kontraktu; ADR-005 jest zapisem, dlaczego wygląda właśnie tak.
 
 ## Zasada nadrzędna
 
@@ -197,9 +200,10 @@ z pulpitu MAP.
 
 Kolejność:
 
-1. **Sprint 0** — zatwierdzenie tego dokumentu jako deklaracji kontraktu;
+1. ~~**Sprint 0** — zatwierdzenie tego dokumentu jako deklaracji kontraktu.~~
+   **Zrobione 2026-08-07** ([ADR-005](../decisions/ADR-005.md)). Pozostaje
    zgłoszenie do backlogu MAP, że zależność „kontrakt statusu po stronie Meal
-   Plannera" ma właściciela i kształt.
+   Plannera" ma właściciela, kształt i status.
 2. **Sprint 1** — powstaje plan i serwerowa lista zakupów, czyli dane, które
    kontrakt ma wystawić.
 3. **Sprint 2** — implementacja `GET /api/v1/integration/summary`, token

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -1,0 +1,49 @@
+---
+status: Active
+last_updated: 2026-08-07
+---
+
+# Portfolio modułów
+
+Ocena wszystkich modułów Meal Plannera względem [North Star](../north-star.md).
+Priorytet wynika z trzech celów: (1) zdejmuje decyzję, (2) zdejmuje zakupy,
+(3) zachowuje używane przepisy.
+
+| Moduł | Cel | Wartość (cel NS) | Priorytet | Status | Kierunek |
+|---|---|---|---|---|---|
+| [Plan posiłków](meal-plan.md) | Tydzień, dzień, posiłek — decyzja podjęta raz | 1, 2 | **Najwyższy** | **Nie istnieje** | **Zbudować** — Sprint 1; bez tego produkt nie jest planerem |
+| [Lista zakupów](shopping-list.md) | Jedna lista, generowana z planu, użyteczna w sklepie | 2 | **Najwyższy** | Działa lokalnie (`localStorage`), tryb sklepowy dobry | **Przebudować**: serwer + generowanie z planu (Sprint 1) |
+| [Dashboard](dashboard.md) | Odpowiedź „co dzisiaj?" na pierwszym ekranie | 1 | Wysoki | **Nie istnieje** (`/` → lista przepisów) | **Zbudować** — Sprint 2, po planie |
+| [Przepisy](recipes.md) | Katalog zasilający plan | 3 | Wysoki | Produkcyjny (64 przepisy, 4 autorów) | **Naprawić i utrzymywać**: widoczność, instrukcje jako kroki; bez rozbudowy |
+| [Import przepisu z URL](recipe-import.md) | Usuwa tarcie wejścia — koniec przepisywania ręcznego | 3 | Wysoki | Gotowy na branchu, **nie na produkcji** | **Wdrożyć** — największa niezrealizowana wartość leżąca w repo |
+| [Integracja z MAP](../integrations/map.md) | „Co dziś na obiad" widoczne z pulpitu MAP | 1, 2 | Średni | Nie istnieje (brak kontraktu) | **Zaprojektować w Sprincie 0, wdrożyć w Sprincie 2** |
+| [Składniki (normalizacja)](ingredients.md) | Agregacja i sortowanie listy po działach sklepu | 2 | Średni | 4 tabele, 0 wierszy, 0 UI | **Zamrozić** do czasu serwerowej listy zakupów |
+| [Dwujęzyczność PL/EN](i18n.md) | Produkt używalny w dwóch językach | 3 | Średni | UI: działa. Treść przepisów: osiągalna tylko przez import | **Dokończyć albo ograniczyć obietnicę** — stan pośredni myli użytkownika |
+| [Konta i dostęp](identity.md) | Własność przepisów, rozdzielenie prywatne/publiczne | 3 | Średni (usługowy) | Produkcyjny, 5 kont | **Utrzymywać**; rozwijać tylko pod potrzeby planu (gospodarstwo domowe, D-2) |
+| [Panel administracyjny i logi](admin.md) | Wgląd operacyjny | — | Niski | Działa; `request_log` 318 tys. wierszy, UI tylko po angielsku | **Zamrozić i ograniczyć**: retencja, dwa widoki zamiast filtrów |
+| Motywy graficzne (cyber/scandi) | Estetyka | — | Niski | Dwa motywy, ~45 KB CSS | **Wybrać jeden** — decyzja w parking lot |
+
+## Czytanie tabeli
+
+**Kluczowe moduły** (produkt bez nich nie ma sensu): Plan posiłków, Lista
+zakupów, Przepisy, Dashboard.
+
+**Enablery** (zwiększają wartość rdzenia): Import z URL, Składniki,
+Dwujęzyczność.
+
+**Poboczne** (koszt utrzymania bez wpływu na cele): Panel administracyjny,
+Motywy graficzne.
+
+Uderzająca obserwacja z [audytu](../audits/product-audit-2026-08-07.md): dwa z
+czterech modułów kluczowych **nie istnieją**, a wszystkie moduły poboczne są
+zaimplementowane i utrzymywane.
+
+## Zasady
+
+- Każdy moduł ma jeden dokument w tym katalogu i jedno źródło prawdy.
+- Moduł, który nie służy żadnemu celowi North Star, nie jest rozwijany — jest
+  zamrażany albo usuwany.
+- Moduły usługowe (konta, panel administracyjny) nie mają własnej roadmapy;
+  rozwijają się wyłącznie pod potrzeby modułów produktowych.
+- Moduł oznaczony jako „nie istnieje" ma dokument, bo dokument jest miejscem,
+  w którym zapada decyzja o jego kształcie — zanim powstanie kod.

--- a/docs/modules/admin.md
+++ b/docs/modules/admin.md
@@ -1,0 +1,57 @@
+---
+status: Zamrożony — utrzymanie
+last_updated: 2026-08-07
+---
+
+# Panel administracyjny i logi
+
+## Purpose
+
+Moduł operacyjny, nie produktowy. Daje właścicielowi instancji wgląd w to, kto
+się logował i co dzieje się z ruchem HTTP. Nie odpowiada na żadne pytanie
+North Star i nie jest rozwijany.
+
+## Current Capabilities
+
+- `/admin` — panel dla roli `super_admin`, dwie zakładki: logi logowań i logi
+  requestów.
+- Zakresy czasowe (dziś / 7 dni / wszystko) i filtry requestów (wszystkie /
+  podejrzane / błędy / zablokowane).
+- Middleware zapisujące każdy request do `request_log` z oznaczaniem
+  podejrzanych ścieżek oraz blokowanie IP.
+- Swagger `/docs` i `/openapi.json` dostępne wyłącznie dla administratora.
+
+## Current Limitations
+
+- **`request_log` rośnie bez retencji** — 318 016 wierszy na produkcji,
+  zdominowanych przez skanowanie botów. Filtr „wszystko" pobiera cały zbiór.
+- Panel jest w całości po angielsku i poza systemem i18n, w aplikacji, która
+  chwali się dwujęzycznością.
+- Ładuje Font Awesome z zewnętrznego CDN — jedyna taka zależność w produkcie.
+- Osobny arkusz stylów (`admin.css`) i osobna konwencja UI względem reszty
+  aplikacji.
+- Poziom rozbudowania telemetrii bezpieczeństwa jest nieproporcjonalny do
+  produktu z pięcioma kontami.
+
+## Design Direction
+
+**Zamrozić i ograniczyć.** Docelowo panel odpowiada na dwa pytania: _kto się
+logował_ i _co się zepsuło_. Wszystko poza tym jest szumem.
+
+Prace utrzymaniowe, w kolejności wartości:
+
+1. Retencja `request_log` (np. 30 dni) albo agregacja — problem rośnie sam.
+2. Ograniczenie logowania szumu skanowania albo oddzielenie go od ruchu
+   aplikacyjnego.
+3. Domyślny zakres inny niż „wszystko".
+
+Nie robić: rozbudowy filtrów, wykresów, alertów, eksportu. Jeżeli pojawi się
+potrzeba realnego monitoringu, właściwym miejscem jest warstwa operacyjna
+(health endpoint + zewnętrzny monitoring), nie panel w aplikacji do gotowania.
+
+## Source Of Truth
+
+- Kod: `app/api/v1/admin.py`, `app/services/admin_service.py`,
+  `app/core/request_log_middleware.py`, `app/core/ip_block.py`,
+  `app/templates/admin_panel.html`
+- Kontekst operacyjny: [audyt produkcyjny 2026-08-04](../audits/meal-planner-production-audit.md), MPP-005

--- a/docs/modules/dashboard.md
+++ b/docs/modules/dashboard.md
@@ -1,0 +1,50 @@
+---
+status: Planned — nie istnieje w kodzie
+last_updated: 2026-08-07
+---
+
+# Dashboard
+
+## Purpose
+
+Pierwszy ekran po zalogowaniu. Ma odpowiadać na jedno pytanie: **co dzisiaj
+powinienem zrobić?** Służy celowi 1 North Star.
+
+Kryterium projektowe: w 10 sekund odpowiedzieć na cztery pytania — _co jemy
+dziś? co jemy dalej w tym tygodniu? czy trzeba coś kupić? gdzie kontynuować
+pracę?_
+
+## Current Capabilities
+
+Brak. `GET /` przekierowuje zalogowanego użytkownika na `/recipes-ui`, czyli na
+płaską listę wszystkich widocznych przepisów posortowaną po dacie dodania.
+
+Na pytanie „co dzisiaj?" obecny pierwszy ekran odpowiada „oto 64 przepisy". To
+nie jest odpowiedź, to jest zrzut bazy danych.
+
+## Current Limitations
+
+Dashboard nie może powstać przed [planem posiłków](meal-plan.md) — bez planu
+nie ma czego pokazać poza liczbą przepisów, a licznik przepisów nie jest
+odpowiedzią na żadne pytanie użytkownika.
+
+## Design Direction
+
+Pełny projekt ekranu, strefy, źródła danych i zasady degradacji:
+[product/dashboard.md](../product/dashboard.md).
+
+Trzy zasady, które obowiązują niezależnie od układu:
+
+1. **Dashboard prezentuje decyzje, nie dane.** Żadnych statystyk, żadnych
+   logów, żadnych liczników dla samego licznika.
+2. **Pusty stan zawsze proponuje jedno konkretne działanie.** „Brak planu na
+   dziś" musi mieć obok siebie przycisk, który to naprawia w jednym kliknięciu.
+3. **Degradacja zamiast błędu.** Strefa bez danych pokazuje komunikat i
+   działanie, nigdy nie wywraca ekranu.
+
+## Source Of Truth
+
+- Projekt: [product/dashboard.md](../product/dashboard.md)
+- Zależność: [Plan posiłków](meal-plan.md),
+  [Lista zakupów](shopping-list.md)
+- Plan: [roadmapa — Sprint 2](../product/roadmap.md)

--- a/docs/modules/i18n.md
+++ b/docs/modules/i18n.md
@@ -1,0 +1,67 @@
+---
+status: Active — połowiczny
+last_updated: 2026-08-07
+---
+
+# Dwujęzyczność PL/EN
+
+## Purpose
+
+Produkt ma być używalny w dwóch językach — interfejs i treść przepisów. Służy
+celowi 3 North Star (przepis pod ręką, także dla osoby anglojęzycznej w
+gospodarstwie).
+
+## Current Capabilities
+
+- Słowniki `app/i18n/pl.json` i `app/i18n/en.json`, 118 kluczy każdy,
+  utrzymywane symetrycznie; helper `t(key, lang)` zarejestrowany jako global
+  Jinja i wstrzykiwany do JS jako `window.I18N`.
+- Rozpoznawanie języka: cookie `lang` → `User.language` → `Accept-Language` →
+  `pl`.
+- Przełącznik PL/EN w nagłówku (`GET /set-lang/{code}`), zapisujący preferencję
+  na koncie zalogowanego użytkownika.
+- Model treści wielojęzycznej: tabela `recipe_translations`
+  (`recipe_id` + `language` → nazwa, opis, instrukcje) z fallbackiem
+  `język → pl → kolumny legacy`.
+- Skrypt backfillu tłumaczeń (`scripts/backfill_recipe_translations.py`,
+  dry-run + `--apply`).
+- Komunikaty i ostrzeżenia importu przetłumaczone na oba języki.
+
+## Current Limitations
+
+- **Nie da się stworzyć treści EN przez UI.** Formularz dodawania i modal
+  edycji nie wysyłają pola `language`, więc `recipe_service` zawsze zapisuje
+  tłumaczenie jako `pl`. Jedyna droga do wiersza `language='en'` prowadzi przez
+  import przepisu z linku (tam jest selektor języka).
+- W efekcie użytkownik przełącza interfejs na EN i **widzi polskie przepisy** —
+  fallback działa poprawnie technicznie i wprowadza w błąd produktowo.
+- Brak jakiegokolwiek UI do dodania drugiego tłumaczenia istniejącego przepisu.
+- Panel administracyjny (`admin_panel.html`) jest w całości po angielsku i poza
+  systemem i18n.
+- 64 istniejące przepisy nie mają wierszy w `recipe_translations` do czasu
+  uruchomienia backfillu — działają wyłącznie dzięki fallbackowi do kolumn
+  legacy.
+
+## Design Direction
+
+Stan pośredni jest najgorszy z możliwych: produkt obiecuje dwujęzyczność i
+dostarcza ją w połowie. Trzeba wybrać jedną z dwóch dróg:
+
+- **Dokończyć** — selektor języka treści w formularzu przepisu plus widok
+  „dodaj tłumaczenie", żeby przełącznik EN znaczył to, co obiecuje. Albo
+- **Ograniczyć obietnicę** — jasno komunikować, że EN dotyczy wyłącznie
+  interfejsu, a treść przepisu jest w języku, w jakim ją zapisano.
+
+Rekomendacja: dokończyć, ale dopiero po Sprincie 1 — dwujęzyczność treści nie
+konkuruje priorytetem z brakiem planu.
+
+Niezależnie od wyboru: uruchomić backfill tłumaczeń, żeby `recipe_translations`
+stały się jedynym źródłem prawdy, a kolumny legacy zeszły do roli mirrora tylko
+do odczytu.
+
+## Source Of Truth
+
+- Kod: `app/core/i18n.py`, `app/i18n/{pl,en}.json`,
+  `app/services/recipe_translation_service.py`
+- Decyzja: `docs/decisions/recipe-translations.md` — dokument żyje na branchu
+  `feature/i18n-recipe-import-ingredients`, poza tym baseline'em

--- a/docs/modules/identity.md
+++ b/docs/modules/identity.md
@@ -30,8 +30,9 @@ Na produkcji: 5 kont, 4 z nich są autorami przepisów.
 ## Current Limitations
 
 - **Brak pojęcia gospodarstwa domowego.** Model zna użytkownika i flagę
-  „publiczny", a produkt służy rodzinie. To blokuje decyzję D-2: czy plan
-  posiłków jest wspólny, czy prywatny.
+  „publiczny", a produkt służy rodzinie. Rozstrzygnięte przez
+  [ADR-002](../decisions/ADR-002.md): encji gospodarstwa **nie wprowadzamy** —
+  granicą gospodarstwa jest granica instancji.
 - Brak samodzielnej rejestracji, resetu hasła i zmiany hasła z poziomu UI —
   konta zakłada administrator.
 - Brak UI zarządzania użytkownikami; panel administracyjny pokazuje wyłącznie
@@ -41,14 +42,17 @@ Na produkcji: 5 kont, 4 z nich są autorami przepisów.
 
 ## Design Direction
 
-Do rozstrzygnięcia w Sprincie 1 razem z modelem planu: **czy wprowadzamy
-gospodarstwo domowe jako byt** (plan, lista zakupów i przepisy współdzielone w
-obrębie domu), **czy pozostajemy przy jednym planie na instancję**.
+Rozstrzygnięte przez [ADR-002](../decisions/ADR-002.md): **jeden plan i jedna
+lista zakupów na instancję**, bez encji gospodarstwa i bez multi-tenancy.
+Wprowadzanie modelu wielu domów byłoby budowaniem SaaS-a bez potrzeby.
 
-Rekomendacja: jeden plan i jedna lista zakupów na instancję w v1 — Meal Planner
-obsługuje jedno gospodarstwo domowe, a wprowadzanie pełnego modelu wielu domów
-byłoby budowaniem SaaS-a bez potrzeby. Flagę `is_public` przy przepisach można
-wtedy uprościć do „mój / wspólny".
+Wynikające z tego zadania dla modułu — wszystkie drobne:
+
+- Plan i lista dostają `created_by` / `updated_by` wyłącznie do audytu, nie do
+  kontroli dostępu.
+- Flagę `is_public` przy przepisach można uprościć do „mój / wspólny", bo
+  „publiczny" w obrębie jednego domu znaczy „wspólny". Osobna zmiana, poza
+  zakresem ADR-002.
 
 Poza tym moduł jest zamrożony: żadnych ról, uprawnień ani mechanizmów kont bez
 konkretnej potrzeby produktowej.

--- a/docs/modules/identity.md
+++ b/docs/modules/identity.md
@@ -1,0 +1,62 @@
+---
+status: Active
+last_updated: 2026-08-07
+---
+
+# Konta i dostęp
+
+## Purpose
+
+Moduł usługowy. Odpowiada za to, kto jest właścicielem przepisu i kto co widzi.
+Nie ma własnej roadmapy — rozwija się wyłącznie pod potrzeby modułów
+produktowych.
+
+## Current Capabilities
+
+- Logowanie hasłem (bcrypt), token JWT w cookie `access_token` (`httponly`,
+  `samesite=lax`, `secure` zależne od środowiska), wylogowanie.
+- Trzy role: `user`, `admin`, `super_admin`. `super_admin` ma dostęp do panelu
+  administracyjnego i do Swaggera.
+- Własność przepisu (`Recipe.user_id`) i widoczność (`is_public`) — przepis
+  widzi właściciel oraz, jeśli publiczny, każdy zalogowany.
+- Preferowany język przypisany do konta (`User.language`).
+- Tworzenie użytkowników przez `POST /users` (tylko admin) i skrypt
+  `scripts/bootstrap_admin.py`.
+- Logowanie prób logowania (`login_log`), opóźnienie po nieudanych próbach,
+  blokowanie IP.
+
+Na produkcji: 5 kont, 4 z nich są autorami przepisów.
+
+## Current Limitations
+
+- **Brak pojęcia gospodarstwa domowego.** Model zna użytkownika i flagę
+  „publiczny", a produkt służy rodzinie. To blokuje decyzję D-2: czy plan
+  posiłków jest wspólny, czy prywatny.
+- Brak samodzielnej rejestracji, resetu hasła i zmiany hasła z poziomu UI —
+  konta zakłada administrator.
+- Brak UI zarządzania użytkownikami; panel administracyjny pokazuje wyłącznie
+  logi.
+- `GET /ingredients/map` nie wymaga uwierzytelnienia — pojedynczy wyjątek od
+  reguły, że wszystko jest za logowaniem.
+
+## Design Direction
+
+Do rozstrzygnięcia w Sprincie 1 razem z modelem planu: **czy wprowadzamy
+gospodarstwo domowe jako byt** (plan, lista zakupów i przepisy współdzielone w
+obrębie domu), **czy pozostajemy przy jednym planie na instancję**.
+
+Rekomendacja: jeden plan i jedna lista zakupów na instancję w v1 — Meal Planner
+obsługuje jedno gospodarstwo domowe, a wprowadzanie pełnego modelu wielu domów
+byłoby budowaniem SaaS-a bez potrzeby. Flagę `is_public` przy przepisach można
+wtedy uprościć do „mój / wspólny".
+
+Poza tym moduł jest zamrożony: żadnych ról, uprawnień ani mechanizmów kont bez
+konkretnej potrzeby produktowej.
+
+## Source Of Truth
+
+- Kod: `app/core/security.py`, `app/api/v1/auth.py`,
+  `app/services/auth_service.py`, `app/services/permissions_service.py`,
+  `app/db/models/user.py`
+- Środowiska i bezpieczeństwo wdrożeniowe:
+  [operations/production-environment.md](../operations/production-environment.md)

--- a/docs/modules/ingredients.md
+++ b/docs/modules/ingredients.md
@@ -48,6 +48,12 @@ Warunek odmrożenia: **istnieje serwerowa lista zakupów generowana z planu**
 (Sprint 1). Dopóki go nie ma, każda praca tutaj powiększa powierzchnię
 utrzymania bez wartości dla użytkownika.
 
+Zamrożenie zostało potwierdzone decyzją
+[ADR-003](../decisions/ADR-003.md): agregacja v1 opiera się na dokładnym
+dopasowaniu nazwy i jednostki, więc Sprint 1 **nie potrzebuje** ani konwersji
+jednostek, ani aliasów, ani sekcji sklepowych. Odmrożenie tego modułu będzie
+wymagało nowego ADR-a rozszerzającego ADR-003.
+
 Kolejność po odmrożeniu:
 
 1. `/api/v1/ingredients/*` + minimalne UI mapowania składnika na słownik

--- a/docs/modules/ingredients.md
+++ b/docs/modules/ingredients.md
@@ -1,0 +1,71 @@
+---
+status: Zamrożony — model istnieje, brak danych i UI
+last_updated: 2026-08-07
+---
+
+# Składniki (normalizacja)
+
+## Purpose
+
+Docelowo: zamienić wolny tekst składników w dane, z których da się zbudować
+sensowną listę zakupów — scalić „pomidor"/„pomidory"/„tomatoes" w jedną
+pozycję, zsumować ilości i posortować listę po działach sklepu. Służy celowi 2
+North Star.
+
+## Current Capabilities
+
+- Schemat w bazie: rozbudowany `ingredients` (nazwy kanoniczne PL/EN, domyślna
+  sekcja sklepu, flaga `is_essential`), `ingredient_aliases`,
+  `recipe_ingredients` (ilość, jednostka, notatka, `parsed_name`,
+  `needs_review`), `store_sections` (nazwy PL/EN, kolejność).
+- Parser linii składnika PL/EN (`app/services/ingredient_parsing/parser.py`) —
+  działa i jest używany przez import przepisu.
+- `GET /ingredients/map` — mapa `nazwa → is_essential` używana przez UI do
+  domyślnego zaznaczania checkboxów przy składnikach przepisu.
+- Import przepisu zapisuje `recipe_ingredients` z `ingredient_id = NULL` —
+  strukturalne dane powstają, ale nie są z niczym powiązane.
+
+## Current Limitations
+
+- **Tabela `ingredients` ma zero wierszy na produkcji.** Cały mechanizm
+  „składnik ważny/nieważny" jest w praktyce bezczynny: brak wpisu oznacza
+  domyślne `True`, więc zawsze wszystko jest zaznaczone.
+- **Brak jakiegokolwiek UI.** Pozycja „Składniki" w menu burger wywołuje toast
+  „funkcja wkrótce dostępna" — jedyny widoczny ślad modułu prowadzi donikąd.
+- **Brak konsumenta danych.** `store_sections` istnieją po to, by sortować
+  listę zakupów po działach sklepu — a lista zakupów jest w `localStorage` i
+  nie wie nic o składnikach.
+- Brak `/api/v1/ingredients/*` i `/api/v1/store-sections`, brak mapowania
+  składnika na słownik, brak tworzenia aliasów, brak backfillu 64 istniejących
+  przepisów.
+
+## Design Direction
+
+**Moduł jest świadomie zamrożony.** To nie jest zaniedbanie — to decyzja
+wynikająca z zasady „nie budujemy modelu danych przed jego konsumentem".
+
+Warunek odmrożenia: **istnieje serwerowa lista zakupów generowana z planu**
+(Sprint 1). Dopóki go nie ma, każda praca tutaj powiększa powierzchnię
+utrzymania bez wartości dla użytkownika.
+
+Kolejność po odmrożeniu:
+
+1. `/api/v1/ingredients/*` + minimalne UI mapowania składnika na słownik
+   (Faza C z pierwotnego planu).
+2. Sekcje sklepowe i sortowanie listy zakupów po działach.
+3. Aliasy — tworzone wyłącznie jawną akcją użytkownika, nigdy automatycznym
+   scalaniem niepewnych dopasowań.
+4. Backfill 64 przepisów — zawsze dry-run i ręczny przegląd raportu (Faza D).
+
+Do tego czasu: **usunąć pozycję „Składniki" z menu**, żeby produkt nie
+pokazywał kontrolki, która nic nie robi.
+
+## Source Of Truth
+
+- Kod: `app/db/models/ingredient.py`, `ingredient_alias.py`,
+  `recipe_ingredient.py`, `store_section.py`,
+  `app/services/ingredient_parsing/`
+- Architektura: `docs/architecture/ingredient-model.md` i decyzja
+  `docs/decisions/ingredient-normalization.md` — oba dokumenty żyją na branchu
+  `feature/i18n-recipe-import-ingredients`, poza tym baseline'em
+- Wcześniejszy przegląd: [ingredients-feature-review.md](../audits/ingredients-feature-review.md)

--- a/docs/modules/meal-plan.md
+++ b/docs/modules/meal-plan.md
@@ -26,17 +26,18 @@ pamięta, które z nich „są na ten tydzień".
 Kształt v1 — celowo minimalny, bo produkt konkuruje z kartką i przegrywa
 liczbą kliknięć, nie brakiem opcji:
 
-- **Jednostka planu to dzień, nie posiłek.** V1 zakłada jeden slot dziennie
-  (obiad) — decyzja D-1 w [roadmapie](../product/roadmap.md). Trzy sloty można
-  dodać później bez łamania modelu; odwrotna droga jest droższa.
+- **Jednostka planu to dzień, nie posiłek.** V1 ma jeden slot dziennie (obiad) —
+  [ADR-001](../decisions/ADR-001.md). Trzy sloty można dodać później bez łamania
+  modelu; odwrotna droga jest droższa.
 - **Tydzień jest widokiem, nie bytem.** Plan to zbiór wpisów `data → przepis`.
   Tydzień w UI to zakres siedmiu dni, nie osobna encja z cyklem życia.
 - **Wpis planu może być pusty albo tekstowy.** „Obiad u rodziców" i „zostało z
   wczoraj" to prawidłowe wpisy. Plan, który akceptuje tylko przepisy z katalogu,
   zostanie porzucony po dwóch tygodniach.
-- **Plan jest własnością gospodarstwa domowego, nie użytkownika** (decyzja D-2).
-  Dziś przepisy mają właściciela i flagę publiczności; plan wymaga pojęcia
-  wspólnoty domowej albo świadomej decyzji, że jest jeden plan na instancję.
+- **Jeden wspólny plan dla instancji** — [ADR-002](../decisions/ADR-002.md).
+  Każdy zalogowany użytkownik widzi i edytuje ten sam plan; nie ma planów per
+  użytkownik ani encji gospodarstwa domowego. Autorstwo przepisów pozostaje
+  osobną osią.
 - **Z planu prowadzą dokładnie dwie akcje**: „Generuj listę zakupów" i „Gotuj"
   (otwórz przepis).
 - **Kopiowanie poprzedniego tygodnia** jest funkcją pierwszej klasy, nie
@@ -51,8 +52,9 @@ dopiero, gdy plan udowodni, że jest używany.
 - **Blokuje**: [Dashboard](dashboard.md),
   [generowanie listy zakupów](shopping-list.md),
   [kontrakt dla MAP](../integrations/map.md).
-- **Jest blokowany przez**: decyzje D-1 (liczba slotów) i D-2 (własność planu)
-  z [roadmapy](../product/roadmap.md).
+- **Był blokowany przez**: decyzje D-1 (liczba slotów) i D-2 (własność planu) —
+  obie podjęte 2026-08-07, [ADR-001](../decisions/ADR-001.md) i
+  [ADR-002](../decisions/ADR-002.md). Moduł nie ma już blokad produktowych.
 
 ## Source Of Truth
 

--- a/docs/modules/meal-plan.md
+++ b/docs/modules/meal-plan.md
@@ -1,0 +1,61 @@
+---
+status: Planned — nie istnieje w kodzie
+last_updated: 2026-08-07
+---
+
+# Plan posiłków
+
+## Purpose
+
+Moduł, w którym zapada decyzja: **co jemy w tym tygodniu**. Jest rdzeniem
+produktu i jedynym modułem, którego brak sprawia, że nazwa „Meal Planner" jest
+nieprawdziwa. Służy celowi 1 North Star i jest warunkiem koniecznym celu 2
+(lista zakupów generowana z planu) oraz dashboardu.
+
+## Current Capabilities
+
+Brak. Moduł nie istnieje: nie ma modelu tygodnia, dnia ani posiłku, nie ma
+endpointów, nie ma UI. Potwierdzone w schemacie bazy i w kodzie
+([audyt produktowy](../audits/product-audit-2026-08-07.md), sekcja 7).
+
+Dziś rolę planu pełni pamięć użytkownika: wybiera przepisy w katalogu i sam
+pamięta, które z nich „są na ten tydzień".
+
+## Design Direction
+
+Kształt v1 — celowo minimalny, bo produkt konkuruje z kartką i przegrywa
+liczbą kliknięć, nie brakiem opcji:
+
+- **Jednostka planu to dzień, nie posiłek.** V1 zakłada jeden slot dziennie
+  (obiad) — decyzja D-1 w [roadmapie](../product/roadmap.md). Trzy sloty można
+  dodać później bez łamania modelu; odwrotna droga jest droższa.
+- **Tydzień jest widokiem, nie bytem.** Plan to zbiór wpisów `data → przepis`.
+  Tydzień w UI to zakres siedmiu dni, nie osobna encja z cyklem życia.
+- **Wpis planu może być pusty albo tekstowy.** „Obiad u rodziców" i „zostało z
+  wczoraj" to prawidłowe wpisy. Plan, który akceptuje tylko przepisy z katalogu,
+  zostanie porzucony po dwóch tygodniach.
+- **Plan jest własnością gospodarstwa domowego, nie użytkownika** (decyzja D-2).
+  Dziś przepisy mają właściciela i flagę publiczności; plan wymaga pojęcia
+  wspólnoty domowej albo świadomej decyzji, że jest jeden plan na instancję.
+- **Z planu prowadzą dokładnie dwie akcje**: „Generuj listę zakupów" i „Gotuj"
+  (otwórz przepis).
+- **Kopiowanie poprzedniego tygodnia** jest funkcją pierwszej klasy, nie
+  dodatkiem — realny użytkownik powtarza 60–70% dań.
+
+Czego v1 nie robi: skalowania porcji, wielu slotów, historii i statystyk,
+sugestii, cykli. Te rzeczy są w [backlogu](../product/backlog.md) i wchodzą
+dopiero, gdy plan udowodni, że jest używany.
+
+## Zależności
+
+- **Blokuje**: [Dashboard](dashboard.md),
+  [generowanie listy zakupów](shopping-list.md),
+  [kontrakt dla MAP](../integrations/map.md).
+- **Jest blokowany przez**: decyzje D-1 (liczba slotów) i D-2 (własność planu)
+  z [roadmapy](../product/roadmap.md).
+
+## Source Of Truth
+
+- Kierunek: [North Star](../north-star.md), priorytet 1
+- Plan: [roadmapa — Sprint 1](../product/roadmap.md)
+- Diagnoza braku: [audyt produktowy](../audits/product-audit-2026-08-07.md)

--- a/docs/modules/recipe-import.md
+++ b/docs/modules/recipe-import.md
@@ -1,0 +1,78 @@
+---
+status: Gotowy na branchu — nie wdrożony na produkcję
+last_updated: 2026-08-07
+---
+
+# Import przepisu z URL
+
+## Purpose
+
+Usuwa największe tarcie wejścia do produktu: nikt nie przepisuje przepisów
+ręcznie. Wklejenie linku ma być najszybszą drogą od „znalazłem coś w
+internecie" do „mam to w planie". Służy celowi 3 North Star i jest enablerem
+dla celu 1 — plan jest tyle wart, ile katalog, z którego się go składa.
+
+## Current Capabilities
+
+- `POST /api/v1/recipe-import/preview` — pobiera stronę, parsuje
+  `schema.org/Recipe` (JSON-LD, w tym `@graph` i wiele bloków), z fallbackiem
+  do parsowania HTML; nic nie zapisuje.
+- Parser składników PL/EN: rozbija linię na ilość, jednostkę, nazwę i notatkę,
+  obsługuje ułamki i zwroty typu „do smaku"; każda pozycja dostaje
+  `confidence` i flagę „wymaga sprawdzenia".
+- **Draft z korektą przez człowieka** — wszystkie pola edytowalne, tabela
+  składników z dodawaniem i usuwaniem wierszy, oznaczone tylko pozycje
+  niepewne („Sprawdź"). Wzorcowe podejście: maszyna proponuje, człowiek
+  zatwierdza.
+- `POST /api/v1/recipe-import/confirm` — zapisuje **wyłącznie** to, co przyszło
+  w payloadzie; nigdy nie pobiera strony ponownie.
+- Opcjonalne pobranie zdjęcia po zatwierdzeniu: whitelist JPEG/PNG/WebP,
+  sniffing magic bytes, własna nazwa pliku; nieudane pobranie nie blokuje
+  zapisu przepisu.
+- Ochrona przed przypadkowym podwójnym zatwierdzeniem (okno 120 s po
+  `user_id` + `source_url` zwraca istniejący przepis).
+- Ostrzeżenia i błędy zmapowane na kody i przetłumaczone na PL/EN — użytkownik
+  widzi zdanie, nie wyjątek.
+- Bezpieczeństwo pobierania: walidacja schematu i portów, odrzucanie userinfo,
+  blokada adresów prywatnych i metadanych, pinowanie połączenia TCP do
+  zwalidowanego IP przy zachowaniu Host/SNI, pełna rewalidacja na każdym
+  przekierowaniu, limit rozmiaru po dekompresji.
+
+## Current Limitations
+
+- **Nie jest na produkcji.** Kod, testy i migracje leżą na branchu
+  `feature/i18n-recipe-import-ingredients`; migracja `69eea78ac02c` nie została
+  jeszcze uruchomiona nawet na RC. To jest największa gotowa wartość w repo,
+  która nikomu nic nie daje.
+- **Pola „Porcje", „Czas przygotowania", „Czas gotowania" są zbierane i
+  wyrzucane.** Schemat `RecipeImportConfirmRequest` je waliduje,
+  `create_recipe_from_import()` ich nie zapisuje, bo model `Recipe` nie ma
+  takich kolumn. Użytkownik traci dane bez ostrzeżenia (P-3 w audycie).
+- Zaimportowany przepis jest zawsze prywatny i — dopóki widoczność w UI jest
+  zepsuta — nie da się go upublicznić.
+- Przełącznik „zapisz składniki jako relacyjne" pokazuje użytkownikowi decyzję
+  techniczną, której znaczenia nie zna; strukturalne składniki i tak nie mają
+  dziś konsumenta.
+- Import jest schowany jako drugorzędny przycisk w zakładce Przepisy, choć jest
+  najszybszą drogą wypełnienia katalogu.
+- Brak zbiorczego importu i brak ponownej synchronizacji ze źródłem.
+
+## Design Direction
+
+- **Wdrożyć.** Kolejność: migracja na RC → smoke na RC → decyzja o merge do
+  `main` → produkcja. Osobno od Sprintu 1, żeby nie łączyć dwóch obszarów
+  ryzyka.
+- Domknąć P-3: zapisać porcje i czasy albo usunąć te pola z formularza.
+- Ukryć przełącznik składników relacyjnych do czasu, aż będą używane; decyzja
+  techniczna nie należy do użytkownika.
+- Po wdrożeniu planu: akcja „importuj i dodaj do planu" jednym krokiem.
+
+## Source Of Truth
+
+- Kod: `app/api/v1/recipe_import.py`, `app/services/recipe_import/`,
+  `app/services/ingredient_parsing/`
+- Architektura `docs/architecture/recipe-import.md`, handoff
+  `docs/handoffs/i18n-recipe-import-ingredients.md` i przegląd produktowy Faz
+  A/B `docs/product/bilingual-recipe-import.md` — wszystkie trzy dokumenty żyją
+  na branchu `feature/i18n-recipe-import-ingredients` razem z kodem, którego
+  dotyczą, i wejdą do tej hierarchii dopiero po zaakceptowaniu tamtego brancha

--- a/docs/modules/recipe-import.md
+++ b/docs/modules/recipe-import.md
@@ -48,6 +48,9 @@ dla celu 1 — plan jest tyle wart, ile katalog, z którego się go składa.
   wyrzucane.** Schemat `RecipeImportConfirmRequest` je waliduje,
   `create_recipe_from_import()` ich nie zapisuje, bo model `Recipe` nie ma
   takich kolumn. Użytkownik traci dane bez ostrzeżenia (P-3 w audycie).
+  Rozstrzygnięte — [ADR-004](../decisions/ADR-004.md): pola zostają i są
+  utrwalane, a `total_time` znika z kontraktu `confirm`, bo formularz go nie
+  pokazuje.
 - Zaimportowany przepis jest zawsze prywatny i — dopóki widoczność w UI jest
   zepsuta — nie da się go upublicznić.
 - Przełącznik „zapisz składniki jako relacyjne" pokazuje użytkownikowi decyzję

--- a/docs/modules/recipes.md
+++ b/docs/modules/recipes.md
@@ -1,0 +1,74 @@
+---
+status: Active
+last_updated: 2026-08-07
+---
+
+# Przepisy
+
+## Purpose
+
+Katalog przepisów zasilający plan posiłków. Służy celowi 3 North Star:
+przepisy istnieją po to, żeby dało się z nich złożyć plan — nie jako cel sam w
+sobie.
+
+## Current Capabilities
+
+- CRUD przepisu: nazwa, opis, składniki (wolny tekst, jeden na linię),
+  instrukcje.
+- Widoczność prywatny/publiczny (`Recipe.is_public`) — przepisy publiczne widzą
+  wszyscy zalogowani, prywatne tylko właściciel; admin i super_admin mają
+  dostęp szerszy.
+- Zdjęcie przepisu: upload, podgląd, usunięcie
+  (`PUT/DELETE /api/v1/recipes/{id}/image`, pliki w `app/static/uploads`).
+- Odznaki na karcie: „MOJE · PRYWATNY/PUBLICZNY" albo „OD <autor>".
+- Wyszukiwanie tekstowe po stronie klienta (`filterRecipes()` — filtruje po
+  wyrenderowanym tekście karty).
+- Podgląd instrukcji w modalu.
+- Zaznaczanie składników i dodanie ich do listy zakupów.
+- Treść przepisu w modelu wielojęzycznym (`recipe_translations`) z fallbackiem
+  do kolumn legacy — patrz [Dwujęzyczność](i18n.md).
+- Metadane pochodzenia dla przepisów zaimportowanych (`source_url`,
+  `source_name`, `source_author`, `imported_at`).
+
+Na produkcji: 64 przepisy, 4 autorów, 58 publicznych, 3 ze zdjęciem, 45 z
+wielolinijkowymi składnikami.
+
+## Current Limitations
+
+- **Widoczność nie działa w UI.** Formularz dodawania nie wysyła `is_public`
+  (każdy nowy przepis jest prywatny), a przełącznik w modalu edycji jest
+  podpięty pod element o zduplikowanym `id="edit-is-public"` z formularza
+  dodawania, więc nie zmienia niczego. Endpoint
+  `PATCH /api/v1/recipes/{id}/visibility` istnieje, ale żadna ścieżka UI go nie
+  wywołuje — to martwy kod obok zepsutej funkcji.
+- **Brak porcji, czasu przygotowania i czasu gotowania** w modelu, mimo że
+  formularz importu te dane zbiera (i po zapisie wyrzuca).
+- **Składniki i instrukcje to wolny tekst.** Instrukcje są przekazywane przez
+  atrybut HTML `data-instructions`, co jest kruche dla długich treści i
+  uniemożliwia widok kroków.
+- **Wyszukiwanie jest prymitywne** — podciąg w wyrenderowanym tekście. Brak
+  tagów, kategorii i filtrów (moje/publiczne, ze zdjęciem, z importu, czas
+  przygotowania).
+- Brak pojęcia „ostatnio gotowane" — nie da się odróżnić przepisu używanego co
+  tydzień od dodanego raz i zapomnianego.
+
+## Design Direction
+
+Moduł jest **utrzymywany, nie rozbudowywany**. Trzy rzeczy do zrobienia,
+wszystkie w kategorii „napraw obietnicę", nie „dodaj funkcję":
+
+1. Jedna, działająca kontrolka widoczności; usunięcie drugiej drogi.
+2. Kolumny `servings` / `prep_time` / `cook_time` albo usunięcie tych pól z
+   importu (decyzja D-4) — dane potrzebne później do skalowania porcji.
+3. Instrukcje jako lista kroków zamiast pola tekstowego w atrybucie HTML.
+
+Filtry i tagi wchodzą dopiero wtedy, gdy rozmiar katalogu je uzasadni.
+Pierwszeństwo ma plan, nie lepsze przeglądanie katalogu.
+
+## Source Of Truth
+
+- Kod: `app/api/v1/recipes.py`, `app/services/recipe_service.py`,
+  `app/db/models/recipe.py`, `app/static/recipes.js` (obiekt `Recipes`)
+- Import: [Import przepisu z URL](recipe-import.md)
+- Wielojęzyczność: ADR `docs/decisions/recipe-translations.md` — dokument żyje
+  na branchu `feature/i18n-recipe-import-ingredients`, poza tym baseline'em

--- a/docs/modules/recipes.md
+++ b/docs/modules/recipes.md
@@ -42,7 +42,9 @@ wielolinijkowymi składnikami.
   `PATCH /api/v1/recipes/{id}/visibility` istnieje, ale żadna ścieżka UI go nie
   wywołuje — to martwy kod obok zepsutej funkcji.
 - **Brak porcji, czasu przygotowania i czasu gotowania** w modelu, mimo że
-  formularz importu te dane zbiera (i po zapisie wyrzuca).
+  formularz importu te dane zbiera (i po zapisie wyrzuca). Rozstrzygnięte —
+  [ADR-004](../decisions/ADR-004.md) nakazuje je utrwalić; wdrożenie w
+  Sprincie 1.
 - **Składniki i instrukcje to wolny tekst.** Instrukcje są przekazywane przez
   atrybut HTML `data-instructions`, co jest kruche dla długich treści i
   uniemożliwia widok kroków.
@@ -58,8 +60,10 @@ Moduł jest **utrzymywany, nie rozbudowywany**. Trzy rzeczy do zrobienia,
 wszystkie w kategorii „napraw obietnicę", nie „dodaj funkcję":
 
 1. Jedna, działająca kontrolka widoczności; usunięcie drugiej drogi.
-2. Kolumny `servings` / `prep_time` / `cook_time` albo usunięcie tych pól z
-   importu (decyzja D-4) — dane potrzebne później do skalowania porcji.
+2. Kolumny `servings` (tekst), `prep_time_minutes` i `cook_time_minutes` —
+   [ADR-004](../decisions/ADR-004.md). Te same pola wchodzą do formularza
+   ręcznego dodawania i edycji: przepis dodany ręcznie nie może być uboższy niż
+   zaimportowany.
 3. Instrukcje jako lista kroków zamiast pola tekstowego w atrybucie HTML.
 
 Filtry i tagi wchodzą dopiero wtedy, gdy rozmiar katalogu je uzasadni.

--- a/docs/modules/shopping-list.md
+++ b/docs/modules/shopping-list.md
@@ -1,0 +1,67 @@
+---
+status: Active — wymaga przebudowy
+last_updated: 2026-08-07
+---
+
+# Lista zakupów
+
+## Purpose
+
+Zamienia decyzję („to jemy w tym tygodniu") w konkretne działanie w sklepie.
+Służy celowi 2 North Star. Docelowo jedyne poprawne źródło listy to plan
+posiłków; ręczne dopisanie pozycji zostaje jako wyjątek.
+
+## Current Capabilities
+
+- Lista pozycji z nazwą, ilością i stanem „zrobione", trzymana w
+  `localStorage` przeglądarki (`Shopping.getList/saveList`).
+- Ręczne dodawanie pozycji, zwiększanie i zmniejszanie ilości.
+- **Tryb zakupów** — osobny tryb interfejsu: duże cele dotykowe, przełączniki
+  „zrobione", pozycje odhaczone zjeżdżają na dół listy, animacja FLIP przy
+  przestawianiu, ochrona przed przypadkowym usunięciem („dotknij ponownie, aby
+  usunąć"). Najlepiej zaprojektowany fragment produktu.
+- Dodanie zaznaczonych składników przepisu do listy z karty przepisu.
+- Import listy przez wklejenie tekstu (jedna pozycja na linię).
+- Czyszczenie listy z potwierdzeniem.
+
+## Current Limitations
+
+- **`localStorage`.** Lista złożona na laptopie nie istnieje w telefonie w
+  sklepie. To unieważnia cały sens najlepiej zrobionego modułu w aplikacji.
+- **Agregacja jest semantycznie błędna.** Pozycja bierze całą linię składnika
+  jako nazwę i zwiększa licznik o 1 przy powtórzeniu, więc „2 łyżki oliwy" z
+  ilością 2 znaczy „dwa razy dwie łyżki". Ilości z przepisów nie są sumowane
+  ani porównywane.
+- **Brak połączenia z planem** — bo planu nie ma. Lista powstaje przez
+  przeklikanie przepisów pojedynczo (~40–70 interakcji na tydzień).
+- Flaga „składnik ważny/nieważny" (`ingredients_map`) jest bezczynna: tabela
+  `ingredients` ma zero wierszy, więc domyślnie wszystko jest zaznaczone.
+- Brak sortowania po działach sklepu, mimo że model `store_sections` już
+  istnieje w schemacie.
+- Brak historii zakupów i brak pojęcia „mam to w domu".
+
+## Design Direction
+
+Sprint 1 przebudowuje moduł w trzech ruchach:
+
+1. **Serwerowa trwałość** — lista per gospodarstwo/użytkownik w bazie, z
+   jednorazową migracją zawartości `localStorage` przy pierwszym uruchomieniu
+   (użytkownik nie może stracić bieżącej listy).
+2. **Generowanie z planu** — jedno kliknięcie „Generuj listę z planu"
+   zastępuje przeklikiwanie przepisów. Ręczne dodawanie zostaje.
+3. **Uczciwa agregacja** (decyzja D-3): sumowanie tylko przy zgodnej jednostce
+   i zgodnej nazwie; wszystko inne trafia jako osobne pozycje z widocznym
+   tekstem źródłowym. Lepiej pokazać dwie pozycje niż skłamać jedną.
+
+Tryb zakupów zostaje bez zmian — jest wzorcem dla reszty produktu, nie
+kandydatem do przeprojektowania.
+
+Sortowanie po działach sklepu i scalanie aliasów („pomidor"/„pomidory") wchodzą
+dopiero po tym, jak lista będzie serwerowa — patrz [Składniki](ingredients.md).
+
+## Source Of Truth
+
+- Kod: `app/static/recipes.js` (obiekty `Shopping`, `ShoppingUI`),
+  `app/templates/recipes.html` (`#shopping-module`)
+- Plan: [roadmapa — Sprint 1](../product/roadmap.md)
+- Zależność: [Plan posiłków](meal-plan.md)

--- a/docs/modules/shopping-list.md
+++ b/docs/modules/shopping-list.md
@@ -44,20 +44,24 @@ posiłków; ręczne dopisanie pozycji zostaje jako wyjątek.
 
 Sprint 1 przebudowuje moduł w trzech ruchach:
 
-1. **Serwerowa trwałość** — lista per gospodarstwo/użytkownik w bazie, z
-   jednorazową migracją zawartości `localStorage` przy pierwszym uruchomieniu
-   (użytkownik nie może stracić bieżącej listy).
+1. **Serwerowa trwałość** — jedna wspólna lista dla instancji
+   ([ADR-002](../decisions/ADR-002.md)), z jednorazową migracją zawartości
+   `localStorage` przy pierwszym uruchomieniu (użytkownik nie może stracić
+   bieżącej listy).
 2. **Generowanie z planu** — jedno kliknięcie „Generuj listę z planu"
    zastępuje przeklikiwanie przepisów. Ręczne dodawanie zostaje.
-3. **Uczciwa agregacja** (decyzja D-3): sumowanie tylko przy zgodnej jednostce
-   i zgodnej nazwie; wszystko inne trafia jako osobne pozycje z widocznym
-   tekstem źródłowym. Lepiej pokazać dwie pozycje niż skłamać jedną.
+3. **Uczciwa agregacja** ([ADR-003](../decisions/ADR-003.md)): sumowanie tylko
+   przy zgodnej nazwie i zgodnej jednostce; różne jednostki trafiają jako
+   osobne pozycje z widocznym tekstem źródłowym, a każda pozycja pamięta, z
+   których przepisów pochodzi. Lepiej pokazać dwie pozycje prawdziwe niż jedną
+   zmyśloną.
 
 Tryb zakupów zostaje bez zmian — jest wzorcem dla reszty produktu, nie
 kandydatem do przeprojektowania.
 
-Sortowanie po działach sklepu i scalanie aliasów („pomidor"/„pomidory") wchodzą
-dopiero po tym, jak lista będzie serwerowa — patrz [Składniki](ingredients.md).
+Sortowanie po działach sklepu i scalanie aliasów („pomidor"/„pomidory") są
+świadomie poza v1 ([ADR-003](../decisions/ADR-003.md)) i wchodzą dopiero po
+tym, jak lista będzie serwerowa — patrz [Składniki](ingredients.md).
 
 ## Source Of Truth
 

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -104,6 +104,7 @@ Wszystko inne czeka w backlogu.
 - Aktywna roadmapa: [product/roadmap.md](product/roadmap.md)
 - Backlog: [product/backlog.md](product/backlog.md)
 - Portfolio modułów: [modules/README.md](modules/README.md)
+- Rejestr decyzji: [decisions/README.md](decisions/README.md)
 - Integracja z MAP: [integrations/map.md](integrations/map.md)
 - Propozycja dashboardu: [product/dashboard.md](product/dashboard.md)
 - Audyt produktowy: [audits/product-audit-2026-08-07.md](audits/product-audit-2026-08-07.md)

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -1,0 +1,109 @@
+---
+status: Active
+last_updated: 2026-08-07
+---
+
+# North Star
+
+To jest najważniejszy dokument Meal Plannera. Każdy sprint, każda funkcja i
+każda decyzja są oceniane względem tego dokumentu — nie względem pomysłów,
+które akurat przyszły do głowy przy kodzie.
+
+## Czym jest Meal Planner
+
+Meal Planner jest **osobistym systemem decyzji żywieniowych gospodarstwa
+domowego**.
+
+Meal Planner **nie** jest książką kucharską.
+Meal Planner **nie** jest społecznościowym serwisem z przepisami.
+Meal Planner **nie** jest aplikacją dietetyczną ani licznikiem kalorii.
+Meal Planner **nie** jest modułem MAP.
+
+Meal Planner jest osobnym produktem z własnym repo, deploymentem, logowaniem i
+roadmapą. MAP go integruje, nie wchłania (ADR-001, ADR-007 w MAP).
+
+## Misja
+
+Skrócić drogę od pytania **„co jemy w tym tygodniu?"** do stanu **„wiem, mam
+kupione, gotuję"**.
+
+## Cele
+
+Meal Planner ma dokładnie trzy cele:
+
+1. **Zdejmuje decyzję.**
+   Odpowiada, co jest dziś i co jest w tym tygodniu, zanim ktokolwiek stanie
+   przed otwartą lodówką o 17:00.
+2. **Zdejmuje zakupy.**
+   Z planu powstaje jedna lista zakupów, aktualna na każdym urządzeniu i
+   użyteczna w ręce w sklepie.
+3. **Zachowuje przepisy, których naprawdę używamy.**
+   Katalog istnieje po to, żeby zasilać plan — nie jako cel sam w sobie.
+
+**Test North Star:** każda nowa funkcja musi odpowiadać na przynajmniej jedno
+pytanie: _Czy pomaga zdecydować, co jeść? Czy skraca drogę do zakupów? Czy
+sprawia, że przepis, którego używamy, jest pod ręką?_ Jeżeli nie odpowiada na
+żadne — trafia do backlogu (parking lot), nie do sprintu.
+
+Trzy cele mają porządek. Cel 1 jest rdzeniem produktu, cel 2 jest jego
+naturalnym wynikiem, cel 3 jest zapleczem dla obu. Historycznie zbudowano
+najpierw cel 3, dlatego produkt do dziś nazywa się planerem, a jest katalogiem
+(patrz [audyt produktowy](audits/product-audit-2026-08-07.md)).
+
+## Zasady rozwoju
+
+- **Plan jest rdzeniem.** Funkcja, która nie dotyka planu ani listy zakupów,
+  ma niski priorytet niezależnie od tego, jak dobrze wygląda.
+- **Jeden krok użytkownika zamiast trzech.** Produkt konkuruje z kartką i
+  pamięcią. Przegrywa nie brakiem funkcji, tylko liczbą kliknięć.
+- **Dane strukturalne dopiero wtedy, gdy mają konsumenta.** Model składników
+  nie rozwija się „na zapas" — rozwija się wtedy, gdy istnieje lista zakupów,
+  która z niego korzysta.
+- **Telefon w sklepie jest pierwszorzędnym ekranem**, nie wersją mobilną
+  desktopu.
+- **Małe, produkcyjne iteracje.** Każda zmiana zostawia produkt prostszym, nie
+  bogatszym w opcje.
+- **Jedno źródło prawdy.** Plan, backlog i decyzje mają po jednym aktywnym
+  dokumencie; reszta to archiwum.
+- **Osobny produkt, jasny kontrakt.** Integracja z MAP odbywa się wyłącznie
+  przez jawny, wersjonowany kontrakt HTTP
+  ([integrations/map.md](integrations/map.md)) — nigdy przez wspólną bazę,
+  wspólną sesję ani kopiowanie danych.
+- **Fail closed.** Wszystko, co wystawione na zewnątrz (kontrakt dla MAP,
+  cokolwiek publicznego), jest domyślnie read-only i domyślnie odmawia.
+
+## Definicja sukcesu
+
+Meal Planner odnosi sukces, gdy:
+
+1. plan tygodnia powstaje w mniej niż 5 minut i nie wymaga notatnika obok,
+2. lista zakupów powstaje z planu automatycznie, a nie przez przeklikiwanie
+   przepisów po kolei,
+3. w sklepie wystarczy telefon i nikt nie wraca po zapomniany składnik,
+4. o 17:00 nikt nie pyta „co jemy?", bo odpowiedź jest na pierwszym ekranie,
+5. MAP pokazuje „co dziś na obiad" i „ile zostało do kupienia" bez wchodzenia
+   do Meal Plannera.
+
+## Priorytety
+
+W kolejności:
+
+1. **Plan tygodnia** — model dnia i posiłku, bez którego nazwa produktu jest
+   nieprawdziwa (cel 1).
+2. **Serwerowa lista zakupów generowana z planu** (cel 2).
+3. **Dashboard odpowiadający na pytanie „co dzisiaj?"** (cel 1).
+4. **Katalog i import przepisów** — utrzymanie i doszlifowanie tego, co już
+   działa (cel 3).
+5. **Kontrakt integracyjny dla MAP** (cel 1 i 2 widziane z zewnątrz).
+
+Wszystko inne czeka w backlogu.
+
+## Dokumenty podrzędne
+
+- Wizja produktu: [product/vision.md](product/vision.md)
+- Aktywna roadmapa: [product/roadmap.md](product/roadmap.md)
+- Backlog: [product/backlog.md](product/backlog.md)
+- Portfolio modułów: [modules/README.md](modules/README.md)
+- Integracja z MAP: [integrations/map.md](integrations/map.md)
+- Propozycja dashboardu: [product/dashboard.md](product/dashboard.md)
+- Audyt produktowy: [audits/product-audit-2026-08-07.md](audits/product-audit-2026-08-07.md)

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -43,12 +43,14 @@ Legenda celu NS: **1** = decyzja, **2** = zakupy, **3** = katalog.
 - Dependencies: RC po migracji, smoke na RC
 - Links: [Recipe Import](../modules/recipe-import.md)
 
-### Cztery decyzje produktowe blokujące Sprint 1 (D-1…D-4)
+### ~~Cztery decyzje produktowe blokujące Sprint 1 (D-1…D-4)~~
 
 - Value: bez nich model planu i listy zakupów nie da się zaprojektować.
 - Cel NS: 1, 2
-- Status: Decision needed
-- Links: [Roadmap — Decyzje do podjęcia](roadmap.md#decyzje-do-podjęcia-blokują-sprint-1)
+- Status: **Done (2026-08-07)** — [ADR-001](../decisions/ADR-001.md),
+  [ADR-002](../decisions/ADR-002.md), [ADR-003](../decisions/ADR-003.md),
+  [ADR-004](../decisions/ADR-004.md)
+- Links: [Rejestr decyzji](../decisions/README.md)
 
 ---
 
@@ -75,7 +77,7 @@ Legenda celu NS: **1** = decyzja, **2** = zakupy, **3** = katalog.
 - Value: lista przestaje ginąć między laptopem a telefonem — dziś to unieważnia najlepiej zrobiony moduł aplikacji.
 - Cel NS: 2
 - Status: Planned (Sprint 1)
-- Dependencies: jednorazowa migracja istniejącego `localStorage`
+- Dependencies: jednorazowa migracja istniejącego `localStorage`; jedna wspólna lista wg [ADR-002](../decisions/ADR-002.md)
 - Links: [Shopping List module](../modules/shopping-list.md)
 
 ### Generowanie listy zakupów z planu
@@ -83,15 +85,23 @@ Legenda celu NS: **1** = decyzja, **2** = zakupy, **3** = katalog.
 - Value: zamienia ~40–70 interakcji tygodniowo w jedno kliknięcie.
 - Cel NS: 1, 2
 - Status: Planned (Sprint 1)
-- Dependencies: model planu, serwerowa lista, D-3
+- Dependencies: model planu, serwerowa lista, reguła agregacji z [ADR-003](../decisions/ADR-003.md)
 - Links: [Shopping List module](../modules/shopping-list.md)
+
+### Kolumny `servings`, `prep_time_minutes`, `cook_time_minutes`
+
+- Value: import przestaje wyrzucać dane użytkownika (P-3); dashboard może pokazać „45 min · 4 porcje"; skalowanie porcji dostaje podstawę.
+- Cel NS: 1, 3
+- Status: Planned (Sprint 1) — [ADR-004](../decisions/ADR-004.md)
+- Dependencies: migracja Alembic; kolejność względem branchu `feature/i18n-recipe-import-ingredients`
+- Links: [Recipes module](../modules/recipes.md), [Recipe Import module](../modules/recipe-import.md)
 
 ### Naprawa kontrolek, które kłamią
 
-- Value: widoczność przepisu (P-1, P-2), pola porcji i czasów w imporcie (P-3), usunięcie martwego „Składniki" (P-5). Najtańsza poprawa zaufania do interfejsu.
+- Value: widoczność przepisu (P-1, P-2) i usunięcie martwego „Składniki" (P-5). Najtańsza poprawa zaufania do interfejsu.
 - Cel NS: 3
 - Status: Planned (Sprint 1)
-- Dependencies: D-4 dla pól porcji/czasów
+- Dependencies: brak; P-3 (porcje i czasy) obsługuje osobna pozycja wg [ADR-004](../decisions/ADR-004.md)
 - Links: [Audyt — sekcja 4.3](../audits/product-audit-2026-08-07.md)
 
 ### Dashboard „co dzisiaj?"

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -1,0 +1,219 @@
+---
+status: Active
+last_updated: 2026-08-07
+---
+
+# Meal Planner Backlog
+
+Backlog trzyma wyłącznie pracę aktywną lub wciąż wartościową. Historia sprintów
+i zamknięte plany żyją w `docs/audits/` i `docs/handoffs/`.
+
+**Zasada wejścia:** pozycja trafia do backlogu tylko, jeśli odpowiada na
+przynajmniej jedno pytanie [North Star](../north-star.md): _pomaga zdecydować,
+co jeść / skraca drogę do zakupów / sprawia, że używany przepis jest pod ręką_.
+Pozycje bez odpowiedzi lądują w parking lot.
+
+Legenda celu NS: **1** = decyzja, **2** = zakupy, **3** = katalog.
+
+---
+
+## Now
+
+### Sprint 0 — Wizja, audyt, kontrakt
+
+- Value: produkt dostaje kryterium, według którego można odrzucać pomysły; MAP dostaje deklarację kontraktu.
+- Cel NS: 1, 2, 3
+- Status: Active
+- Dependencies: brak
+- Links: [Audyt produktowy](../audits/product-audit-2026-08-07.md), [North Star](../north-star.md)
+
+### Uruchomienie migracji `69eea78ac02c` na RC
+
+- Value: RC przestaje być o jedną migrację za branchem; odblokowuje decyzję o wdrożeniu importu.
+- Cel NS: 3
+- Status: Active (jedyna niewykonana migracja)
+- Dependencies: backup `fastapi_db_rc`, dostęp do VPS
+- Links: handoff `docs/handoffs/i18n-recipe-import-ingredients.md` na branchu `feature/i18n-recipe-import-ingredients`
+
+### Decyzja o wdrożeniu importu przepisu z URL na produkcję
+
+- Value: najlepsza funkcja produktu jest gotowa i leży na branchu, nie dając nikomu wartości.
+- Cel NS: 3
+- Status: Decision needed
+- Dependencies: RC po migracji, smoke na RC
+- Links: [Recipe Import](../modules/recipe-import.md)
+
+### Cztery decyzje produktowe blokujące Sprint 1 (D-1…D-4)
+
+- Value: bez nich model planu i listy zakupów nie da się zaprojektować.
+- Cel NS: 1, 2
+- Status: Decision needed
+- Links: [Roadmap — Decyzje do podjęcia](roadmap.md#decyzje-do-podjęcia-blokują-sprint-1)
+
+---
+
+## Next
+
+### Model planu: tydzień → dzień → posiłek
+
+- Value: rdzeń produktu; bez niego nazwa „Meal Planner" jest nieprawdziwa.
+- Cel NS: 1
+- Status: Planned (Sprint 1)
+- Dependencies: D-1, D-2
+- Links: [Meal Plan module](../modules/meal-plan.md)
+
+### Ekran planu tygodnia
+
+- Value: decyzja na cały tydzień podjęta raz, w jednym miejscu, w kilka minut.
+- Cel NS: 1
+- Status: Planned (Sprint 1)
+- Dependencies: model planu
+- Links: [Meal Plan module](../modules/meal-plan.md)
+
+### Serwerowa lista zakupów
+
+- Value: lista przestaje ginąć między laptopem a telefonem — dziś to unieważnia najlepiej zrobiony moduł aplikacji.
+- Cel NS: 2
+- Status: Planned (Sprint 1)
+- Dependencies: jednorazowa migracja istniejącego `localStorage`
+- Links: [Shopping List module](../modules/shopping-list.md)
+
+### Generowanie listy zakupów z planu
+
+- Value: zamienia ~40–70 interakcji tygodniowo w jedno kliknięcie.
+- Cel NS: 1, 2
+- Status: Planned (Sprint 1)
+- Dependencies: model planu, serwerowa lista, D-3
+- Links: [Shopping List module](../modules/shopping-list.md)
+
+### Naprawa kontrolek, które kłamią
+
+- Value: widoczność przepisu (P-1, P-2), pola porcji i czasów w imporcie (P-3), usunięcie martwego „Składniki" (P-5). Najtańsza poprawa zaufania do interfejsu.
+- Cel NS: 3
+- Status: Planned (Sprint 1)
+- Dependencies: D-4 dla pól porcji/czasów
+- Links: [Audyt — sekcja 4.3](../audits/product-audit-2026-08-07.md)
+
+### Dashboard „co dzisiaj?"
+
+- Value: pierwszy ekran przestaje pokazywać bazę danych i zaczyna odpowiadać.
+- Cel NS: 1
+- Status: Planned (Sprint 2)
+- Dependencies: model planu, serwerowa lista zakupów
+- Links: [Projekt dashboardu](dashboard.md)
+
+### Kontrakt integracyjny dla MAP (`GET /integration/summary`)
+
+- Value: MAP pokazuje „co dziś na obiad" i „ile zostało do kupienia" bez wchodzenia do Meal Plannera; zamyka zależność z backlogu MAP.
+- Cel NS: 1, 2
+- Status: Planned (Sprint 2)
+- Dependencies: dane dashboardu, token serwisowy
+- Links: [Integracja z MAP](../integrations/map.md)
+
+---
+
+## Later
+
+### Skalowanie porcji
+
+- Value: ten sam przepis na 2 i na 6 osób bez liczenia w głowie; warunek sensownej listy zakupów.
+- Cel NS: 1, 2
+- Status: Idea
+- Dependencies: `Recipe.servings` (D-4), strukturalne składniki
+
+### Historia „co jedliśmy" i sugestie
+
+- Value: eliminuje powtarzalność planów i pustą kartkę przy planowaniu.
+- Cel NS: 1
+- Status: Idea
+- Dependencies: plan działający przez kilka tygodni
+
+### Ingredient Engine — mapowanie, aliasy, sekcje sklepowe
+
+- Value: lista zakupów sortowana po działach sklepu i scalająca „pomidory"/„pomidor".
+- Cel NS: 2
+- Status: Idea — **świadomie zablokowane** do czasu, aż serwerowa lista zakupów będzie z tego korzystać
+- Dependencies: serwerowa lista zakupów, generowanie z planu
+- Links: [Ingredients module](../modules/ingredients.md)
+
+### Backfill 64 przepisów o strukturalne składniki
+
+- Value: istniejący katalog zaczyna działać z generowaniem listy, nie tylko nowe przepisy.
+- Cel NS: 2, 3
+- Status: Idea
+- Dependencies: Ingredient Engine, zawsze dry-run + ręczny przegląd
+
+### Tryb gotowania
+
+- Value: kroki, timery, ekran, który nie gaśnie — telefon w kuchni jako drugi kontekst po sklepie.
+- Cel NS: 3
+- Status: Idea
+
+### Dokończenie dwujęzyczności treści przepisu
+
+- Value: przełącznik EN przestaje być fasadą (P-4).
+- Cel NS: 3
+- Status: Idea
+- Dependencies: decyzja, czy tłumaczenie jest ręczne, czy wspomagane
+- Links: [i18n module](../modules/i18n.md)
+
+### Filtry i tagi w katalogu
+
+- Value: znalezienie przepisu przestaje zależeć od pamiętania jego nazwy.
+- Cel NS: 3
+- Status: Idea
+- Dependencies: rozmiar katalogu uzasadniający filtry
+
+### Migracja domeny na `meal.maciak.online` + `rc.meal.maciak.online`
+
+- Value: zgodność z docelowym ekosystemem MAP (ADR-007 po stronie MAP).
+- Cel NS: —
+- Status: Idea (operacyjne)
+- Dependencies: nginx, certyfikaty, aktualizacja kontraktu MAP
+
+### Retencja `request_log`
+
+- Value: baza przestaje rosnąć o szum botów (318 tys. wierszy).
+- Cel NS: —
+- Status: Idea (operacyjne)
+- Links: [Admin module](../modules/admin.md)
+
+### Jedna akcja zapisu dla MAP (dodanie pozycji do listy zakupów)
+
+- Value: „kup mleko" zapisane rano w MAP trafia na listę bez przełączania aplikacji.
+- Cel NS: 2
+- Status: Idea — **dopiero po** udowodnieniu wartości kontraktu read-only
+- Links: [Integracja z MAP](../integrations/map.md)
+
+---
+
+## Parking lot
+
+### Wybór jednego motywu graficznego — decyzja potrzebna
+
+- Value: każda zmiana UI kosztuje dziś podwójnie; motyw „cyber" jest sprzeczny z domeną produktu.
+- Status: Decision needed
+
+### Kalorie, makroskładniki, cele dietetyczne
+
+- Status: Deferred — inny produkt, inna motywacja użytkownika
+
+### Społeczność: komentarze, oceny, publiczny katalog
+
+- Status: Deferred — Meal Planner obsługuje jedno gospodarstwo domowe
+
+### Natywna aplikacja mobilna
+
+- Status: Deferred — responsywne UI z trybem zakupów rozwiązuje ten sam problem taniej
+
+### Integracja z zakupami online / API sklepów
+
+- Status: Deferred — wysoki koszt i zależność zewnętrzna przed dowodem, że lista jest używana między urządzeniami
+
+### AI generujące plan tygodnia / OCR przepisów ze zdjęć
+
+- Status: Deferred — najpierw stabilna warstwa planu i danych
+
+### Cyberpunkowe migające tło (z `ISSUES.md`)
+
+- Status: Rejected — nie odpowiada na żadne pytanie North Star

--- a/docs/product/backlog.md
+++ b/docs/product/backlog.md
@@ -116,7 +116,7 @@ Legenda celu NS: **1** = decyzja, **2** = zakupy, **3** = katalog.
 
 - Value: MAP pokazuje „co dziś na obiad" i „ile zostało do kupienia" bez wchodzenia do Meal Plannera; zamyka zależność z backlogu MAP.
 - Cel NS: 1, 2
-- Status: Planned (Sprint 2)
+- Status: Planned (Sprint 2) — kontrakt zatwierdzony [ADR-005](../decisions/ADR-005.md)
 - Dependencies: dane dashboardu, token serwisowy
 - Links: [Integracja z MAP](../integrations/map.md)
 

--- a/docs/product/dashboard.md
+++ b/docs/product/dashboard.md
@@ -1,0 +1,105 @@
+---
+status: Sprint 0 deliverable — projekt do realizacji w Sprincie 2
+last_updated: 2026-08-07
+---
+
+# Dashboard — projekt
+
+Projekt pierwszego ekranu Meal Plannera. **Bez implementacji** — to
+specyfikacja wejściowa dla Sprintu 2, po tym jak Sprint 1 dostarczy plan i
+serwerową listę zakupów.
+
+## Zasada
+
+Dashboard odpowiada w 10 sekund na cztery pytania:
+
+1. **Co jemy dziś?**
+2. **Co jemy dalej w tym tygodniu?**
+3. **Czy trzeba coś kupić?**
+4. **Gdzie kontynuować pracę?**
+
+Wszystko, co nie odpowiada na jedno z tych pytań, nie trafia na dashboard.
+Statystyki, liczniki, logi i wykresy nie trafiają na dashboard nigdy.
+
+Dziś pierwszy ekran odpowiada na te pytania listą 64 przepisów posortowanych po
+dacie dodania, czyli nie odpowiada wcale
+([audyt](../audits/product-audit-2026-08-07.md), sekcja 5).
+
+## Układ
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  NAGŁÓWEK: Meal Planner · czwartek, 7 sierpnia · PL/EN · ☰   │
+├──────────────────────────────────────────────────────────────┤
+│  ① DZIŚ                                                       │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │  [zdjęcie]   KURCZAK Z WARZYWAMI                       │  │
+│  │              45 min · 4 porcje                          │  │
+│  │              [ Gotuj ]   [ Zmień ]                      │  │
+│  └────────────────────────────────────────────────────────┘  │
+├──────────────────────────────────────────────────────────────┤
+│  ② JUTRO                                                      │
+│  pt · Zupa dyniowa            [ Zobacz ]                     │
+├───────────────────────────────┬──────────────────────────────┤
+│  ③ TEN TYDZIEŃ                │  ④ ZAKUPY                    │
+│  pn ✓  wt ✓  śr ✓  cz ✓      │  12 pozycji do kupienia      │
+│  pt ✓  sb ·  nd ·             │  [ Otwórz listę ]            │
+│  [ Zaplanuj tydzień ]         │  [ Odśwież z planu ]         │
+├───────────────────────────────┴──────────────────────────────┤
+│  ⑤ SZYBKIE AKCJE                                              │
+│  [ Importuj z linku ]  [ Dodaj przepis ]  [ Szukaj przepisu ] │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Mapowanie na pytania: ①→1, ②③→2, ④→3, ⑤→4.
+
+## Strefy — treść, źródła i stan pusty
+
+| # | Strefa | Źródło danych | Stan pusty |
+|---|--------|---------------|------------|
+| ① | **Dziś** | wpis planu na dzisiejszą datę + przepis | „Nie ma planu na dziś" + trzy propozycje z ostatnio gotowanych, każda z przyciskiem „Wybierz na dziś" (jedno kliknięcie kończy pusty stan) |
+| ② | **Jutro** | wpis planu na jutro | „Jutro jeszcze nie zaplanowane" + [Zaplanuj] |
+| ③ | **Ten tydzień** | wpisy planu w zakresie bieżącego tygodnia | Siedem pustych kropek + [Zaplanuj tydzień] jako główne wezwanie do działania |
+| ④ | **Zakupy** | serwerowa lista zakupów: liczba pozycji nieodhaczonych | „Lista jest pusta" + [Wygeneruj z planu], jeśli plan zawiera cokolwiek |
+| ⑤ | **Szybkie akcje** | statyczne | — |
+
+## Zasady projektowe
+
+1. **Jedna dominanta.** Strefa ① zajmuje najwięcej miejsca i jest jedyną z
+   dużym zdjęciem. Jeżeli użytkownik przeczyta tylko ją, dostał wartość
+   produktu.
+2. **Pusty stan zawsze proponuje jedno konkretne działanie**, nigdy samego
+   komunikatu. „Brak planu na dziś" bez przycisku jest błędem projektowym, nie
+   stanem.
+3. **Maksymalnie jedno wezwanie do działania na strefę.** Dwa przyciski
+   równorzędne oznaczają, że decyzja została przerzucona na użytkownika.
+4. **Bez liczników dla samego licznika.** „64 przepisy" nie trafia na
+   dashboard; „12 pozycji do kupienia" trafia, bo prowadzi do działania.
+5. **Degradacja zamiast błędu.** Strefa bez danych pokazuje komunikat i akcję;
+   błąd jednej strefy nie wywraca ekranu.
+6. **Mobile first.** Na telefonie strefy układają się pionowo w kolejności
+   ①②③④⑤ — ten sam porządek wartości.
+7. **Dashboard nie edytuje.** [Zmień], [Zaplanuj], [Otwórz listę] prowadzą do
+   właściwych ekranów. Dashboard prezentuje i kieruje.
+8. **Zero elementów operacyjnych.** Logi, statusy usług, wersje i telemetria
+   nie należą do ekranu, na którym użytkownik pyta, co zjeść.
+
+## Relacja do MAP
+
+Strefy ①②③④ to dokładnie te dane, które wystawia
+[kontrakt integracyjny dla MAP](../integrations/map.md). To nie jest zbieg
+okoliczności — jeden zestaw danych obsługuje pierwszy ekran Meal Plannera i
+kafelek w MAP. Kontrakt implementuje się po dashboardzie, na gotowych danych,
+nie równolegle.
+
+Różnica jest w głębokości: dashboard Meal Plannera pokazuje zdjęcie, czas i
+porcje; MAP pokazuje jedno zdanie i link.
+
+## Zakres Sprintu 2 (propozycja)
+
+Kolejność według wartości: ① Dziś → ④ Zakupy → ③ Ten tydzień → ② Jutro →
+⑤ Szybkie akcje. Pierwsze dwie strefy wystarczą, żeby pierwszy ekran przestał
+być listą przepisów — to minimalny cel.
+
+Zmiana strony startowej (`/` → dashboard zamiast `/recipes-ui`) następuje
+dopiero wtedy, gdy strefy ① i ④ działają na prawdziwych danych.

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -40,9 +40,10 @@ funkcjami.
 
 1. Przyjąć [North Star](../north-star.md) i [Vision](../product/vision.md) jako
    obowiązujące kryterium przyjmowania zadań do sprintów.
-2. Przyjąć [kontrakt integracyjny dla MAP](../integrations/map.md) jako
-   deklarację (implementacja: Sprint 2) i zgłosić go do backlogu MAP jako
-   spełnioną zależność „kontrakt statusu po stronie Meal Plannera".
+2. ~~Przyjąć [kontrakt integracyjny dla MAP](../integrations/map.md).~~
+   **Zrobione 2026-08-07** — [ADR-005](../decisions/ADR-005.md), kontrakt v1
+   read-only; implementacja w Sprincie 2. Pozostaje zgłoszenie do backlogu MAP
+   spełnionej zależności „kontrakt statusu po stronie Meal Plannera".
 3. Zamknąć wiszące elementy poprzedniej pracy:
    - uruchomić migrację `69eea78ac02c` na RC (jedyna niewykonana),
    - domknąć decyzję o wdrożeniu importu przepisu na produkcję,

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -48,20 +48,28 @@ funkcjami.
    - domknąć decyzję o wdrożeniu importu przepisu na produkcję,
    - zdecydować, czy branch `feature/i18n-recipe-import-ingredients` idzie do
      `main`.
-4. Podjąć cztery decyzje produktowe blokujące Sprint 1 (patrz „Decyzje do
-   podjęcia" poniżej).
+4. ~~Podjąć cztery decyzje produktowe blokujące Sprint 1.~~ **Zrobione
+   2026-08-07** — [ADR-001](../decisions/ADR-001.md) …
+   [ADR-004](../decisions/ADR-004.md).
+5. Zaktualizować tagline produktu tak, by nie przeczył North Star.
+   **Zrobione 2026-08-07** — `README.md`.
 
 ## Następnie
 
 **Sprint 1 — Tydzień i lista zakupów.** Moment, w którym nazwa produktu staje
 się prawdziwa.
 
-- Model planu: tydzień → dzień → posiłek (jeden slot na dzień w v1).
-- Ekran planu tygodnia z przypisywaniem przepisu do dnia.
-- Serwerowa lista zakupów per użytkownik (koniec `localStorage`).
-- Generowanie listy zakupów z planu, z sensowną agregacją ilości.
-- Naprawa kontrolek, które dziś kłamią: widoczność przepisu, pola porcji/czasów
-  w imporcie, usunięcie martwej pozycji „Składniki" z menu.
+- Model planu: `data → przepis albo tekst`, jeden wpis na dzień
+  ([ADR-001](../decisions/ADR-001.md)), wspólny dla instancji
+  ([ADR-002](../decisions/ADR-002.md)).
+- Ekran planu tygodnia — siedem pól, kopiowanie poprzedniego tygodnia.
+- Serwerowa lista zakupów, jedna wspólna, z jednorazową migracją zawartości
+  `localStorage`.
+- Generowanie listy z planu z agregacją wg [ADR-003](../decisions/ADR-003.md).
+- Kolumny `servings` / `prep_time_minutes` / `cook_time_minutes` i zapisywanie
+  ich przy imporcie ([ADR-004](../decisions/ADR-004.md)).
+- Naprawa kontrolek, które dziś kłamią: widoczność przepisu, usunięcie martwej
+  pozycji „Składniki" z menu.
 
 **Sprint 2 — Dashboard i integracja.**
 
@@ -104,18 +112,21 @@ się prawdziwa.
   Powód: łamie ADR-001 i ADR-007 po stronie MAP oraz izolację działającej
   produkcji.
 
-## Decyzje do podjęcia (blokują Sprint 1)
+## Decyzje odblokowujące Sprint 1 — podjęte
 
-| # | Decyzja | Dlaczego blokuje |
+Wszystkie cztery decyzje zapadły przy przeglądzie Sprintu 0 (2026-08-07).
+Sprint 1 nie ma już blokad produktowych.
+
+| # | Decyzja | Rozstrzygnięcie |
 |---|---|---|
-| D-1 | Ile slotów posiłkowych na dzień w v1: **jeden (obiad)** czy trzy (śniadanie/obiad/kolacja)? | Determinuje model danych, ekran planu i złożoność generowania listy |
-| D-2 | Czy plan jest **wspólny dla gospodarstwa** czy per użytkownik? | Dziś przepisy są per użytkownik z flagą publiczny; plan wspólny wymaga pojęcia gospodarstwa domowego |
-| D-3 | Jak agregujemy ilości w liście zakupów w v1: **sumowanie tylko przy zgodnej jednostce, reszta jako osobne pozycje** czy pełna normalizacja jednostek? | Decyduje, czy Ingredient Engine jest potrzebny w Sprincie 1, czy dopiero później |
-| D-4 | Czy `Recipe` dostaje kolumny `servings` / `prep_time` / `cook_time`, czy usuwamy te pola z formularza importu? | Dziś dane są zbierane i wyrzucane (P-3 w audycie); stan pośredni jest niedopuszczalny |
+| D-1 | Liczba slotów posiłkowych na dzień | **Jeden — obiad.** Slot nie jest osobną encją; wpis może być tekstowy. [ADR-001](../decisions/ADR-001.md) |
+| D-2 | Własność planu | **Jeden wspólny plan i jedna wspólna lista dla instancji.** Bez planów per użytkownik i bez multi-tenancy. [ADR-002](../decisions/ADR-002.md) |
+| D-3 | Agregacja składników | **Sumowanie tylko przy zgodnej nazwie i zgodnej jednostce**; różne jednostki dają osobne pozycje. Bez konwersji i bez aliasów w v1. [ADR-003](../decisions/ADR-003.md) |
+| D-4 | Porcje i czasy | **Utrwalane w modelu**: `servings` (tekst), `prep_time_minutes`, `cook_time_minutes`. `total_time` znika z formularza zatwierdzania. [ADR-004](../decisions/ADR-004.md) |
 
-Rekomendacja: D-1 → jeden slot, D-2 → wspólny dla gospodarstwa, D-3 → tylko
-zgodne jednostki, D-4 → dodać kolumny (dane są potrzebne dla skalowania porcji
-i dla dashboardu).
+Najważniejsza konsekwencja łączna: **Sprint 1 nie potrzebuje Ingredient
+Engine.** ADR-003 świadomie odracza konwersję jednostek i scalanie aliasów, co
+utrzymuje zakres Sprintu 1 przy planie i liście zakupów.
 
 ## Ryzyka i blokady
 

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -1,0 +1,137 @@
+---
+status: Active
+last_updated: 2026-08-07
+current_milestone: Sprint 0 — Wizja i audyt produktowy
+current_goal: Ustalić, czym Meal Planner jest i czym nie jest, zamknąć wiszące elementy poprzedniego sprintu i zdefiniować kontrakt integracyjny dla MAP — bez rozpoczynania prac programistycznych nad nowymi funkcjami.
+---
+
+# Meal Planner Roadmap
+
+Roadmapa opisuje produkt, nie backend. Kierunek nadrzędny:
+[North Star](../north-star.md). Diagnoza stanu wyjściowego:
+[audyt produktowy](../audits/product-audit-2026-08-07.md).
+
+## Obecny stan
+
+- Produkcja działa publicznie, jako `systemd` + `nginx` + PostgreSQL
+  `fastapi_db`; RC działa na osobnej bazie `fastapi_db_rc`, uruchamiane na
+  żądanie.
+- Katalog przepisów działa: CRUD, zdjęcia, widoczność prywatny/publiczny, role.
+  Na produkcji 64 przepisy, 4 autorów, 5 kont.
+- Import przepisu z URL (schema.org + fallback HTML, draft z korektą,
+  pobieranie zdjęcia) jest zaimplementowany i przetestowany na branchu
+  `feature/i18n-recipe-import-ingredients`; **nie jest jeszcze na produkcji**.
+- Dwujęzyczne UI PL/EN działa; treść przepisów w EN jest osiągalna wyłącznie
+  przez import z linku.
+- Lista zakupów działa wyłącznie w `localStorage` przeglądarki.
+- Model normalizacji składników (`ingredients`, `ingredient_aliases`,
+  `recipe_ingredients`, `store_sections`) istnieje w schemacie i nie ma
+  jeszcze ani UI, ani danych.
+- **Nie istnieje plan tygodnia, dzień, posiłek, historia ani dashboard.**
+- Warstwa operacyjna uporządkowana: Alembic (7 migracji, jeden head), 121
+  testów, backup zweryfikowany, runbooki wdrożenia i rollbacku.
+- Meal Planner nie jest zintegrowany z MAP; MAP nie ma jeszcze kontraktu, z
+  którego mógłby korzystać.
+
+## Teraz
+
+**Sprint 0 — Wizja i audyt produktowy.** Bez prac programistycznych nad nowymi
+funkcjami.
+
+1. Przyjąć [North Star](../north-star.md) i [Vision](../product/vision.md) jako
+   obowiązujące kryterium przyjmowania zadań do sprintów.
+2. Przyjąć [kontrakt integracyjny dla MAP](../integrations/map.md) jako
+   deklarację (implementacja: Sprint 2) i zgłosić go do backlogu MAP jako
+   spełnioną zależność „kontrakt statusu po stronie Meal Plannera".
+3. Zamknąć wiszące elementy poprzedniej pracy:
+   - uruchomić migrację `69eea78ac02c` na RC (jedyna niewykonana),
+   - domknąć decyzję o wdrożeniu importu przepisu na produkcję,
+   - zdecydować, czy branch `feature/i18n-recipe-import-ingredients` idzie do
+     `main`.
+4. Podjąć cztery decyzje produktowe blokujące Sprint 1 (patrz „Decyzje do
+   podjęcia" poniżej).
+
+## Następnie
+
+**Sprint 1 — Tydzień i lista zakupów.** Moment, w którym nazwa produktu staje
+się prawdziwa.
+
+- Model planu: tydzień → dzień → posiłek (jeden slot na dzień w v1).
+- Ekran planu tygodnia z przypisywaniem przepisu do dnia.
+- Serwerowa lista zakupów per użytkownik (koniec `localStorage`).
+- Generowanie listy zakupów z planu, z sensowną agregacją ilości.
+- Naprawa kontrolek, które dziś kłamią: widoczność przepisu, pola porcji/czasów
+  w imporcie, usunięcie martwej pozycji „Składniki" z menu.
+
+**Sprint 2 — Dashboard i integracja.**
+
+- Dashboard odpowiadający na pytanie „co dzisiaj?"
+  ([projekt](dashboard.md)).
+- Endpoint `GET /api/v1/integration/summary` — read-only kontrakt dla MAP.
+- Deep-linki, z których MAP korzysta (`/plan?date=…`, `/shopping`).
+
+## Później
+
+- Skalowanie porcji i przeliczanie składników.
+- Historia „co jedliśmy" i sugestie na podstawie rotacji.
+- Ingredient Engine (Fazy C/D): mapowanie składników na słownik, aliasy,
+  sekcje sklepowe, sortowanie listy po działach sklepu — **dopiero po** tym,
+  jak serwerowa lista zakupów będzie z tego korzystać.
+- Backfill 64 istniejących przepisów o strukturalne składniki (zawsze dry-run
+  + ręczny przegląd).
+- Tryb gotowania: kroki, timery, ekran kuchenny.
+- Dokończenie dwujęzyczności treści przepisów (dodanie tłumaczenia z poziomu
+  edycji).
+- Migracja domeny na `meal.maciak.online` i `rc.meal.maciak.online`.
+- Jedna, wąska akcja zapisu dla MAP (dodanie pozycji do listy zakupów) — po
+  udowodnieniu wartości kontraktu read-only.
+
+## Odłożone
+
+- **Kalorie, makroskładniki, cele dietetyczne.**
+  Powód: inny produkt, inna motywacja użytkownika; nie odpowiada na żadne
+  pytanie North Star.
+- **Społeczność, komentarze, oceny, publiczne udostępnianie przepisów światu.**
+  Powód: Meal Planner obsługuje jedno gospodarstwo domowe.
+- **Aplikacja mobilna natywna.**
+  Powód: responsywne UI z trybem zakupów rozwiązuje ten sam problem taniej.
+- **Integracja z zakupami online / API sklepów.**
+  Powód: wysoki koszt, zależność zewnętrzna, brak dowodu, że lista zakupów jest
+  w ogóle używana między urządzeniami.
+- **Rozpoznawanie przepisów ze zdjęć / OCR / AI generujące plan.**
+  Powód: najpierw potrzebna jest stabilna warstwa planu i danych.
+- **Wchłonięcie Meal Plannera do repozytorium MAP.**
+  Powód: łamie ADR-001 i ADR-007 po stronie MAP oraz izolację działającej
+  produkcji.
+
+## Decyzje do podjęcia (blokują Sprint 1)
+
+| # | Decyzja | Dlaczego blokuje |
+|---|---|---|
+| D-1 | Ile slotów posiłkowych na dzień w v1: **jeden (obiad)** czy trzy (śniadanie/obiad/kolacja)? | Determinuje model danych, ekran planu i złożoność generowania listy |
+| D-2 | Czy plan jest **wspólny dla gospodarstwa** czy per użytkownik? | Dziś przepisy są per użytkownik z flagą publiczny; plan wspólny wymaga pojęcia gospodarstwa domowego |
+| D-3 | Jak agregujemy ilości w liście zakupów w v1: **sumowanie tylko przy zgodnej jednostce, reszta jako osobne pozycje** czy pełna normalizacja jednostek? | Decyduje, czy Ingredient Engine jest potrzebny w Sprincie 1, czy dopiero później |
+| D-4 | Czy `Recipe` dostaje kolumny `servings` / `prep_time` / `cook_time`, czy usuwamy te pola z formularza importu? | Dziś dane są zbierane i wyrzucane (P-3 w audycie); stan pośredni jest niedopuszczalny |
+
+Rekomendacja: D-1 → jeden slot, D-2 → wspólny dla gospodarstwa, D-3 → tylko
+zgodne jednostki, D-4 → dodać kolumny (dane są potrzebne dla skalowania porcji
+i dla dashboardu).
+
+## Ryzyka i blokady
+
+- **Największe ryzyko produktowe:** dołożenie kolejnej funkcji do warstwy
+  treści (np. Ingredient Engine) zamiast zbudowania warstwy decyzji. Produkt
+  stanie się wtedy jeszcze lepszym katalogiem i dalej nie będzie planerem.
+- Serwerowa lista zakupów oznacza migrację danych z `localStorage` —
+  użytkownicy mogą stracić bieżącą listę, jeśli nie przewidzimy jednorazowego
+  importu przy pierwszym uruchomieniu.
+- Model planu wchodzi w te same tabele, które właśnie dostały 7 migracji.
+  Każda zmiana schematu wymaga backupu i przejścia przez RC (runbook:
+  `operations/sprint-0-production-rollout.md`).
+- Import z linku nie był jeszcze na produkcji; wdrożenie go i budowa planu
+  jednocześnie zwiększają powierzchnię ryzyka. Rekomendacja: wdrożyć import
+  osobno, przed Sprintem 1.
+- `request_log` rośnie bez retencji (318 tys. wierszy) — nie blokuje produktu,
+  ale będzie rosnąć razem z nim.
+- Kontrakt dla MAP tworzy zewnętrzną zależność. Musi być wersjonowany od
+  pierwszego dnia, inaczej zmiana w Meal Plannerze zepsuje pulpit MAP.

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -1,0 +1,96 @@
+---
+status: Active
+last_updated: 2026-08-07
+---
+
+# Meal Planner Product Vision
+
+Dokument nadrzędny: [North Star](../north-star.md). Wizja konkretyzuje North
+Star na poziomie produktu; nie powtarza go.
+
+## Jaki problem rozwiązuje Meal Planner
+
+Problem nie brzmi „nie mam gdzie trzymać przepisów". Przepisy da się trzymać w
+notatkach, w zakładkach przeglądarki i w głowie — i tak właśnie są trzymane.
+
+Problem brzmi:
+
+> **Codziennie trzeba podjąć tę samą decyzję („co jemy?"), a raz w tygodniu
+> przełożyć ją na zakupy — i obie te czynności są wykonywane od zera, z
+> pamięci, pod presją czasu.**
+
+Koszt tego problemu to: powtarzalne dania, zakupy „na oko", wyprawy do sklepu
+po jeden brakujący składnik, marnowanie jedzenia i decyzja o 17:00 w złym
+nastroju.
+
+Meal Planner rozwiązuje ten problem w trzech ruchach:
+
+1. **plan** — decyzja podjęta raz, na spokojnie, dla całego tygodnia,
+2. **lista** — plan zamieniony automatycznie w jedną listę zakupów,
+3. **katalog** — przepisy zebrane po to, żeby plan dało się złożyć w minuty, a
+   nie w pół godziny.
+
+## Product Intent
+
+Meal Planner ma być aplikacją otwieraną **dwa razy w tygodniu i raz dziennie**:
+
+- raz w tygodniu, żeby ułożyć plan i wygenerować listę,
+- raz na zakupach, w sklepie, z telefonu,
+- codziennie na 10 sekund, żeby zobaczyć, co jest dziś.
+
+To jest zupełnie inny profil użycia niż „przeglądarka przepisów" i wynikają z
+niego wszystkie decyzje UX: pierwszy ekran to plan i dziś, nie lista wszystkich
+przepisów; tryb zakupów jest osobnym, dużym trybem; szukanie przepisu jest
+czynnością pomocniczą, nie główną.
+
+## Czym Meal Planner jest dzisiaj
+
+Repozytorium zawiera działający produkt: logowanie z rolami, katalog przepisów
+(64 przepisy, 4 autorów na produkcji), widoczność prywatny/publiczny, zdjęcia,
+import przepisu z linku (schema.org + fallback HTML, z twardym SSRF guardem),
+dwujęzyczne UI PL/EN, lokalną listę zakupów z trybem sklepowym oraz panel
+administracyjny z logami. Warstwa operacyjna jest uporządkowana: Alembic,
+rozdzielone produkcja i RC, backup, runbook wdrożeniowy.
+
+Nie zawiera natomiast **planu**: nie ma tygodnia, dnia, posiłku, historii ani
+generowania listy zakupów z planu. Lista zakupów żyje w `localStorage` jednej
+przeglądarki.
+
+Innymi słowy: zbudowano zaplecze (cel 3) i część kuchni (cel 2), ale sala, do
+której przychodzi użytkownik (cel 1), jeszcze nie istnieje. Pełna diagnoza:
+[audyt produktowy](../audits/product-audit-2026-08-07.md).
+
+## Ekosystem
+
+Meal Planner jest jedną z trzech aplikacji ekosystemu `maciak.online` obok
+Public Website i MAP (Personal Operating System). Docelowa domena:
+`meal.maciak.online`, przedprodukcja: `rc.meal.maciak.online`.
+
+Meal Planner **pozostaje osobnym produktem**: osobne repo, deployment,
+logowanie, roadmapa i cykl wydań. MAP go integruje przez jawny kontrakt —
+szczegóły i granice: [integrations/map.md](../integrations/map.md).
+
+## Product Principles
+
+- **Produkt odpowiada na pytanie, nie prezentuje danych.** Pierwszy ekran mówi
+  „dziś jest X, do kupienia zostało Y", a nie „oto 64 przepisy".
+- **Plan generuje listę; lista nie jest wpisywana ręcznie.** Ręczne dopisanie
+  pozycji zostaje jako wyjątek, nie jako główna ścieżka.
+- **Każdy element UI ma właściciela w postaci celu North Star.** Element bez
+  celu jest usuwany, nie utrzymywany.
+- **Nie budujemy modelu danych przed jego konsumentem.**
+- **Pusty stan zawsze proponuje jedno konkretne działanie.**
+- **Dwujęzyczność dotyczy interfejsu i treści przepisu, nie jest połowiczna** —
+  jeżeli produkt oferuje przełącznik EN, musi istnieć droga do treści EN.
+
+## Near-Term Product Focus
+
+1. **Zamienić katalog w planer** — model tygodnia/dnia/posiłku i ekran planu.
+2. **Przenieść listę zakupów na serwer i generować ją z planu.**
+3. **Dać pierwszy ekran, który odpowiada „co dzisiaj?"**
+   ([projekt dashboardu](dashboard.md)).
+4. **Zamknąć niedokończone obietnice UI** (widoczność przepisu, treść EN,
+   martwy przycisk „Składniki") — produkt nie może pokazywać kontrolek, które
+   nic nie robią.
+5. **Wystawić kontrakt integracyjny dla MAP** — read-only, wersjonowany, fail
+   closed.


### PR DESCRIPTION
Sprint 0 deliverable: the product documentation layer for Meal Planner, on top of the production baseline. **Documentation only — no code, configuration, migration or infrastructure change.**

## What this adds

- **North Star** — Meal Planner is a household's meal-decision system, not a recipe catalogue. Three goals (decide / shop / keep the recipes we actually use) and the test every feature has to pass.
- **Product vision, roadmap, backlog** — Sprint 0 and Sprint 1 scope, deferred items with reasons.
- **Product audit (2026-08-07)** — the diagnosis this layer is built on: the product is named after a planner it does not have, the shopping list lives in `localStorage`, and ten UI controls promise things they do not do.
- **Module portfolio** — 10 module documents with purpose, status and direction. Two core modules (meal plan, dashboard) do not exist yet; two side modules are frozen.
- **Decision register** — ADR-001…ADR-005.
- **MAP integration contract** — read-only v1, one versioned summary endpoint, separate service token, no shared session, no data replication, no writes from MAP.
- **Dashboard design** — input spec for Sprint 2, not implemented.
- **README** — documentation hierarchy and a tagline that no longer contradicts the North Star.

## Decisions recorded

| ADR | Decision |
|---|---|
| ADR-001 | One meal slot per day (dinner) in v1 |
| ADR-002 | One shared plan and shopping list per instance; no household entity, no multi-tenancy |
| ADR-003 | Aggregate only on matching name and unit; no unit conversion, no aliases in v1 |
| ADR-004 | Persist `servings` (text), `prep_time_minutes`, `cook_time_minutes`; drop `total_time` from the confirm contract |
| ADR-005 | MAP integration is a read-only contract in v1 |

## Base and scope

Based on `ops/meal-production-baseline`, which reflects the running production checkout — not on the previous `main`, which was 8 commits behind. `main` has since been fast-forwarded to that same baseline, so this PR applies cleanly and linearly.

This branch deliberately carries **no** changes from `feature/i18n-recipe-import-ingredients`. That branch's documents (recipe import architecture, ingredient model, two decision records, the handoff) are referenced as plain text rather than links, so nothing here dangles. They become ADR-006 and ADR-007 when that branch is accepted.

## Review notes

- Every relative link resolves; every document carries `status` and `last_updated`.
- Two items are still open by design and marked `Decision needed`: deploying the URL import to production, and picking a single theme.
- Sprint 1 has no remaining product blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)