### PR TITLE
fix: bezpieczne renderowanie UI przepisów i naprawa kłamiących kontrolek

### DIFF
--- a/app/static/recipes.js
+++ b/app/static/recipes.js
@@ -99,6 +99,21 @@ const UI = {
 
 };
 
+/**
+ * Tworzy element z klasą i tekstem.
+ *
+ * Treść przepisu (nazwa, opis, instrukcje, składniki) pochodzi od użytkownika i
+ * może być pokazana innym użytkownikom, gdy przepis jest publiczny. Nie wolno
+ * jej skleić w string i oddać do innerHTML - `textContent` nigdy nie parsuje
+ * HTML, więc znaczniki i handlery zdarzeń zostają zwykłym tekstem.
+ */
+function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined && text !== null) node.textContent = String(text);
+    return node;
+}
+
 const RecipesUI = {
     add: {
         name: () => document.getElementById("name"),
@@ -107,6 +122,7 @@ const RecipesUI = {
         instructions: () => document.getElementById("instructions"),
         preview: () => document.getElementById("add-preview"),
         image: () => document.getElementById("add-image"),
+        isPublic: () => document.getElementById("add-is-public"),
         form: () => document.getElementById("add-recipe-form")
     },
     edit: {
@@ -116,6 +132,7 @@ const RecipesUI = {
         instructions: () => document.getElementById("edit-instructions"),
         preview: () => document.getElementById("edit-preview"),
         image: () => document.getElementById("edit-image"),
+        isPublic: () => document.getElementById("edit-is-public"),
         modal: () => document.getElementById("edit-modal")
     },
     list: () => document.getElementById("recipes-container")
@@ -125,7 +142,16 @@ function clearForm(fields) {
     Object.values(fields)
         .map(fn => fn())
         .filter(el => el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA"))
-        .forEach(el => el.value = "");
+        .forEach(el => {
+            // Checkboxa nie czyści się przez .value - trzeba go odznaczyć, inaczej
+            // przełącznik widoczności zostaje włączony po zapisaniu przepisu i
+            // następny przepis dostaje ustawienie, którego nikt nie wybrał.
+            if (el.type === "checkbox") {
+                el.checked = false;
+                return;
+            }
+            el.value = "";
+        });
 }
 
 
@@ -152,93 +178,117 @@ const Recipes = {
     },
 
     renderRecipeBadge(recipe) {
-    if (recipe.is_owner) {
-        return `
-            <span class="recipe-badge mine ${recipe.is_public ? "public" : "private"}">
-                MY · ${recipe.is_public ? "PUBLIC" : "PRIVATE"}
-            </span>
-        `;
-    }
+        if (recipe.is_owner) {
+            return el(
+                "span",
+                `recipe-badge mine ${recipe.is_public ? "public" : "private"}`,
+                `MY · ${recipe.is_public ? "PUBLIC" : "PRIVATE"}`
+            );
+        }
 
-    return `
-        <span class="recipe-badge foreign">
-            BY ${recipe.author_username ?? "USER"}
-        </span>
-    `;
+        // author_username przychodzi z bazy i trafia na kartę cudzego przepisu.
+        return el("span", "recipe-badge foreign", `BY ${recipe.author_username ?? "USER"}`);
     },
 
 
     render(recipes) {
         const container = RecipesUI.list();
-        container.innerHTML = "";
-        recipes.forEach(r => {
-            const isOwner = r.is_owner === true;
-            const box = document.createElement("div");
-            box.className = "recipe-box";
-            box.innerHTML = `
-            <div class="recipe-header">
-                <h3>${r.name}</h3>
-                ${this.renderRecipeBadge(r)}
-            </div>
-            <div class="recipe-body">
-            <div class="recipe-text">
-                <p><strong>Description:</strong> ${r.description}</p>
-                <p><strong>Ingredients:</strong></p>
-                <div class="ingredients-list">
-                    ${this.renderIngredients(r.ingredients)}
-                </div>
-            </div>
-            ${r.image ? `
-            <div class="recipe-image-wrap">
-                <img src="${r.image}" class="recipe-image">
-            </div>
-            ` : ""}
-            </div>
-                <div class="recipe-actions">
-    <!-- ZAWSZE -->
-    <button class="secondary"
-        data-action="instructions"
-        data-instructions="${r.instructions}">
-        View Instructions
-    </button>
+        container.replaceChildren();
+        recipes.forEach(r => container.appendChild(this.renderRecipeCard(r)));
+    },
 
-    <button class="secondary add-to-list"
-        data-action="add-to-list"
-        data-id="${r.id}">
-        + Add to list
-    </button>
+    /**
+     * Buduje kartę przepisu wyłącznie przez DOM API.
+     *
+     * Każde pole pochodzące od użytkownika (name, description, instructions,
+     * ingredients, author_username, image) wchodzi przez textContent, dataset
+     * albo właściwość elementu - nigdy przez sklejanie HTML-a. Nazwy klas i
+     * struktura są takie same jak w poprzedniej wersji szablonowej, żeby CSS i
+     * delegacja zdarzeń działały bez zmian.
+     */
+    renderRecipeCard(r) {
+        const box = el("div", "recipe-box");
 
-    <!-- TYLKO WŁAŚCICIEL -->
-    ${isOwner ? `
-        <button class="secondary"
-            data-action="edit"
-            data-id="${r.id}">
-            Manage
-        </button>
+        const header = el("div", "recipe-header");
+        header.appendChild(el("h3", null, r.name ?? ""));
+        header.appendChild(this.renderRecipeBadge(r));
+        box.appendChild(header);
 
+        const body = el("div", "recipe-body");
+        const textCol = el("div", "recipe-text");
 
+        const description = el("p");
+        description.appendChild(el("strong", null, "Description:"));
+        description.appendChild(document.createTextNode(` ${r.description ?? ""}`));
+        textCol.appendChild(description);
 
+        const ingredientsLabel = el("p");
+        ingredientsLabel.appendChild(el("strong", null, "Ingredients:"));
+        textCol.appendChild(ingredientsLabel);
 
-    ` : ""}
-</div>
+        textCol.appendChild(this.renderIngredients(r.ingredients));
+        body.appendChild(textCol);
 
-            `;
-            container.appendChild(box);
-        });
+        if (r.image) {
+            const imageWrap = el("div", "recipe-image-wrap");
+            const image = el("img", "recipe-image");
+            // .src jako właściwość: ścieżka nigdy nie jest parsowana jako HTML,
+            // więc nie da się nią wyjść z atrybutu.
+            image.src = r.image;
+            imageWrap.appendChild(image);
+            body.appendChild(imageWrap);
+        }
+        box.appendChild(body);
+
+        const actions = el("div", "recipe-actions");
+
+        const instructionsBtn = el("button", "secondary", "View Instructions");
+        instructionsBtn.dataset.action = "instructions";
+        // dataset zapisuje wartość atrybutu bez parsowania - cudzysłowy i znaczniki
+        // w instrukcjach nie mają jak z niego wyjść.
+        instructionsBtn.dataset.instructions = r.instructions ?? "";
+        actions.appendChild(instructionsBtn);
+
+        const addToListBtn = el("button", "secondary add-to-list", "+ Add to list");
+        addToListBtn.dataset.action = "add-to-list";
+        addToListBtn.dataset.id = String(r.id);
+        actions.appendChild(addToListBtn);
+
+        if (r.is_owner === true) {
+            const manageBtn = el("button", "secondary", "Manage");
+            manageBtn.dataset.action = "edit";
+            manageBtn.dataset.id = String(r.id);
+            actions.appendChild(manageBtn);
+        }
+
+        box.appendChild(actions);
+        return box;
     },
 
     renderIngredients(ingredients) {
-        return ingredients.split("\n").map(ing => {
+        const wrapper = el("div", "ingredients-list");
+
+        (ingredients ?? "").split("\n").forEach(ing => {
             const key = ing.trim().toLowerCase();
             const essential = this.state.ingredientsMap[key] ?? true;
 
-            return `
-          <label class="ingredient" style="display:flex; align-items:center; gap:6px;">
-            <input type="checkbox" class="shopping-item" ${essential ? "checked" : ""}>
-            <span>${ing}</span>
-          </label>
-        `;
-        }).join("");
+            const label = el("label", "ingredient");
+            label.style.display = "flex";
+            label.style.alignItems = "center";
+            label.style.gap = "6px";
+
+            const checkbox = el("input", "shopping-item");
+            checkbox.type = "checkbox";
+            checkbox.checked = essential;
+            label.appendChild(checkbox);
+
+            // Musi zostać <span> tuż za checkboxem - addRecipeToShoppingList()
+            // czyta nazwę składnika przez cb.nextElementSibling.textContent.
+            label.appendChild(el("span", null, ing));
+            wrapper.appendChild(label);
+        });
+
+        return wrapper;
     },
 
     actions: {
@@ -263,7 +313,10 @@ const Recipes = {
                 name: RecipesUI.add.name().value,
                 description: RecipesUI.add.description().value,
                 ingredients: RecipesUI.add.ingredients().value,
-                instructions: RecipesUI.add.instructions().value
+                instructions: RecipesUI.add.instructions().value,
+                // Bez tego formularz zbierał wartość przełącznika widoczności i
+                // ją wyrzucał - każdy nowy przepis wychodził prywatny.
+                is_public: RecipesUI.add.isPublic().checked
             };
 
             Api.post("/api/v1/recipes/", recipe)
@@ -289,7 +342,7 @@ const Recipes = {
             editingId = id;
 
             RecipesUI.edit.name().value = recipe.name || "";
-            document.getElementById("edit-is-public").checked = recipe.is_public;
+            RecipesUI.edit.isPublic().checked = recipe.is_public;
             RecipesUI.edit.description().value = recipe.description || "";
             RecipesUI.edit.ingredients().value = recipe.ingredients || "";
             RecipesUI.edit.instructions().value = recipe.instructions || "";
@@ -309,7 +362,7 @@ const Recipes = {
             try {
                 const recipe = {
                     name: RecipesUI.edit.name().value,
-                    is_public: document.getElementById("edit-is-public").checked,
+                    is_public: RecipesUI.edit.isPublic().checked,
                     description: RecipesUI.edit.description().value,
                     ingredients: RecipesUI.edit.ingredients().value,
                     instructions: RecipesUI.edit.instructions().value
@@ -447,40 +500,49 @@ const Shopping = {
             oldPositions.set(el.dataset.id, el.getBoundingClientRect());
         });
         const sortedList = [...list].sort((a, b) => a.done - b.done);
-        listEl.innerHTML = "";
+        listEl.replaceChildren();
         if (sortedList.length === 0) {
-            listEl.innerHTML = `<p class="muted">Your shopping list is empty 🛒</p>`;
+            listEl.appendChild(el("p", "muted", "Your shopping list is empty 🛒"));
             return;
         }
         sortedList.forEach(item => {
-            const div = document.createElement("div");
-            div.className = `shopping-item ${item.done ? "done" : ""}`;
+            // item.name to linia składnika przepisu, więc na liście zakupów ląduje
+            // ta sama niezaufana treść co na karcie przepisu.
+            const div = el("div", `shopping-item ${item.done ? "done" : ""}`);
             div.dataset.id = item.id;
-            div.innerHTML = `
-                <div class="shopping-main">
-                    <label class="done-switch" style="${this.state.mode ? "" : "display:none"}">
-                        <input type="checkbox" ${item.done ? "checked" : ""}
-                            data-action="toggle-done"
-                            data-id="${item.id}">
-                        <span class="done-slider"></span>
-                    </label>
-                    <span class="item-name">${item.name}</span>
-                </div>
-                <span class="item-qty">${item.qty}</span>
-                ${this.state.mode ? "" : `
-                <div class="qty-controls">
-                    <button class="qty-btn"
-                        data-action="decrease"
-                        data-id="${item.id}"
-                        ${item.done ? "disabled" : ""}>-</button>
 
-                    <button class="qty-btn"
-                        data-action="increase"
-                        data-id="${item.id}"
-                        ${item.done ? "disabled" : ""}>+</button>
-                </div>
-                `}
-            `;
+            const main = el("div", "shopping-main");
+
+            const doneSwitch = el("label", "done-switch");
+            if (!this.state.mode) doneSwitch.style.display = "none";
+
+            const doneCheckbox = document.createElement("input");
+            doneCheckbox.type = "checkbox";
+            doneCheckbox.checked = !!item.done;
+            doneCheckbox.dataset.action = "toggle-done";
+            doneCheckbox.dataset.id = item.id;
+            doneSwitch.appendChild(doneCheckbox);
+            doneSwitch.appendChild(el("span", "done-slider"));
+
+            main.appendChild(doneSwitch);
+            main.appendChild(el("span", "item-name", item.name));
+            div.appendChild(main);
+
+            div.appendChild(el("span", "item-qty", item.qty));
+
+            if (!this.state.mode) {
+                const controls = el("div", "qty-controls");
+
+                [["decrease", "-"], ["increase", "+"]].forEach(([action, label]) => {
+                    const btn = el("button", "qty-btn", label);
+                    btn.dataset.action = action;
+                    btn.dataset.id = item.id;
+                    btn.disabled = !!item.done;
+                    controls.appendChild(btn);
+                });
+
+                div.appendChild(controls);
+            }
 
             listEl.appendChild(div);
             div.classList.add("just-added");
@@ -691,7 +753,10 @@ const App = {
             shoppingInput.addEventListener("keydown", e => {
                 if (e.key === "Enter") {
                     e.preventDefault();
-                    Shopping.addItem();
+                    // Shopping.addItem() nigdy nie istniało - Enter rzucał
+                    // TypeError i pozycja nie trafiała na listę, mimo że
+                    // przycisk "Add" obok działał.
+                    addShoppingItem();
                 }
             });
         }
@@ -826,11 +891,16 @@ async function confirmDeleteYes() {
 function showInstructions(text) {
     const modalText = document.getElementById("modal-text");
 
-    // zamieniamy newline na <br> TUTAJ, bez hacków w HTML
-    modalText.innerHTML = text
-        .split("\n")
-        .map(line => line.trim())
-        .join("<br>");
+    // Łamanie linii budujemy z prawdziwych elementów <br>, a same linie wchodzą
+    // jako tekst. Sklejenie ich w string i przypisanie do innerHTML wykonywało
+    // znaczniki zapisane w instrukcjach przepisu.
+    modalText.replaceChildren();
+    const lines = (text ?? "").split("\n").map(line => line.trim());
+
+    lines.forEach((line, index) => {
+        if (index > 0) modalText.appendChild(document.createElement("br"));
+        modalText.appendChild(document.createTextNode(line));
+    });
 
     UI.openModal("modal");
 }
@@ -1093,9 +1163,8 @@ async function removeImage() {
 }
 
 
-function openIngredientsModal() {
-    UI.toast("Ingredients feature coming soon", "info");
-}
+// openIngredientsModal() usunięte razem z pozycją menu "Ingredients" - jedyne,
+// co robiło, to toast "funkcja wkrótce dostępna".
 
 
 function toggleBurger() {

--- a/app/templates/recipes.html
+++ b/app/templates/recipes.html
@@ -65,7 +65,8 @@
             >
             Switch Theme
             </button>
-        <button class="secondary small" onclick="openIngredientsModal()">Ingredients</button>
+        {# Pozycja "Ingredients" usunięta: prowadziła wyłącznie do toastu
+           "feature coming soon". Wraca, gdy będzie co pokazać. #}
 
         <form method="get" action="/logout">
             <button type="submit" class="burger-item danger">Logout</button>
@@ -84,7 +85,7 @@
 <div id="add-recipe-form" class="content">
     <input id="name" placeholder="Name">
         <label class="visibility-switch">
-        <input type="checkbox" id="edit-is-public">
+        <input type="checkbox" id="add-is-public">
         <span class="slider"></span>
         <span class="labels">
             <span class="private">PRIVATE</span>

--- a/tests/test_recipe_controls.py
+++ b/tests/test_recipe_controls.py
@@ -1,0 +1,220 @@
+"""Kontrolki, które obiecywały coś, czego nie robiły.
+
+Statyczne sprawdzenia nad źródłem - projekt nie ma runnera JS. Każdy test
+odpowiada jednemu znalezisku audytu produktowego i ma pilnować, żeby kontrolka
+nie zaczęła znowu kłamać.
+"""
+import os
+import re
+import sys
+import tempfile
+import unittest
+from collections import Counter
+from pathlib import Path
+from unittest import mock
+
+APP_DIR = Path(__file__).resolve().parent.parent / "app"
+RECIPES_HTML = (APP_DIR / "templates" / "recipes.html").read_text(encoding="utf-8")
+RECIPES_JS_RAW = (APP_DIR / "static" / "recipes.js").read_text(encoding="utf-8")
+
+
+def _strip_js_comments(source: str) -> str:
+    """Usuwa komentarze przed skanowaniem źródła.
+
+    Bez tego komentarz opisujący naprawiony błąd (np. wzmianka o dawnym
+    wywołaniu) wygląda dla testu jak żywy kod i zapala fałszywy alarm.
+    """
+    without_block = re.sub(r"/\*.*?\*/", "", source, flags=re.DOTALL)
+    return re.sub(r"(?m)^\s*//.*$|(?<=[;,)\s])//[^\n]*$", "", without_block)
+
+
+RECIPES_JS = _strip_js_comments(RECIPES_JS_RAW)
+
+
+def purge_app_modules() -> None:
+    for name in list(sys.modules):
+        if name == "app" or name.startswith("app."):
+            sys.modules.pop(name)
+
+
+def _payload_body(function_source_marker: str) -> str:
+    """Ciało literału obiektu wysyłanego przez daną akcję (`const recipe = {...}`)."""
+    match = re.search(
+        function_source_marker + r".*?\bconst recipe = \{(.*?)\n\s*\};",
+        RECIPES_JS,
+        re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"Nie znaleziono payloadu dla: {function_source_marker}")
+    return match.group(1)
+
+
+class DuplicateIdTests(unittest.TestCase):
+    """P-2: id="edit-is-public" występowało dwa razy - w formularzu dodawania i
+    w modalu edycji. getElementById zwraca pierwszy, więc przełącznik w modalu
+    edycji czytał i zapisywał cudzy element."""
+
+    def test_no_duplicate_ids_in_template(self) -> None:
+        ids = re.findall(r'id="([^"]+)"', RECIPES_HTML)
+        duplicates = {id_ for id_, count in Counter(ids).items() if count > 1}
+        self.assertEqual(duplicates, set(), f"Zduplikowane id: {duplicates}")
+
+    def test_add_and_edit_forms_have_separate_visibility_checkboxes(self) -> None:
+        self.assertIn('id="add-is-public"', RECIPES_HTML)
+        self.assertIn('id="edit-is-public"', RECIPES_HTML)
+
+
+class VisibilitySwitchTests(unittest.TestCase):
+    """P-1: przełącznik PRIVATE/PUBLIC w formularzu dodawania był renderowany,
+    ale create() nie czytało jego wartości - każdy nowy przepis wychodził
+    prywatny niezależnie od ustawienia."""
+
+    def test_create_payload_sends_is_public(self) -> None:
+        self.assertIn("is_public:", _payload_body(r"create\(\)\s*\{"))
+
+    def test_update_payload_still_sends_is_public(self) -> None:
+        self.assertIn("is_public:", _payload_body(r"async update\(\)\s*\{"))
+
+    def test_each_form_reads_its_own_checkbox(self) -> None:
+        self.assertRegex(RECIPES_JS, r'isPublic: \(\) => document\.getElementById\("add-is-public"\)')
+        self.assertRegex(RECIPES_JS, r'isPublic: \(\) => document\.getElementById\("edit-is-public"\)')
+        # Żadna ścieżka nie może już sięgać po element po surowym id z pominięciem
+        # akcesora - to właśnie tak formularz dodawania trafiał w pole edycji.
+        self.assertNotIn('document.getElementById("edit-is-public")', _payload_body(r"create\(\)\s*\{"))
+
+    def test_clear_form_unchecks_checkboxes_instead_of_clearing_value(self) -> None:
+        # el.value = "" na checkboxie nic nie odznacza, więc przełącznik
+        # zostawał włączony dla kolejnego dodawanego przepisu.
+        self.assertIn('el.type === "checkbox"', RECIPES_JS)
+        self.assertIn("el.checked = false", RECIPES_JS)
+
+
+class ShoppingEnterKeyTests(unittest.TestCase):
+    """Enter w polu listy zakupów wołał Shopping.addItem(), którego nigdy nie
+    było - rzucał TypeError i pozycja nie trafiała na listę."""
+
+    def test_enter_handler_calls_an_existing_function(self) -> None:
+        self.assertNotIn("Shopping.addItem()", RECIPES_JS)
+        self.assertIn("function addShoppingItem()", RECIPES_JS)
+
+        handler = re.search(
+            r'shoppingInput\.addEventListener\("keydown".*?\}\);',
+            RECIPES_JS,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(handler)
+        self.assertIn("addShoppingItem()", handler.group(0))
+
+    def test_every_shopping_method_called_on_the_object_actually_exists(self) -> None:
+        """Ogólniejszy strażnik: żadne Shopping.foo() w kodzie nie może
+        wskazywać na metodę, której obiekt nie definiuje."""
+        called = set(re.findall(r"\bShopping\.(\w+)\(", RECIPES_JS))
+        shopping_block = re.search(r"const Shopping = \{(.*?)\n\};", RECIPES_JS, re.DOTALL)
+        self.assertIsNotNone(shopping_block)
+        defined = set(re.findall(r"^\s{4}(?:async\s+)?(\w+)[\(:]", shopping_block.group(1), re.MULTILINE))
+
+        missing = sorted(name for name in called if name not in defined)
+        self.assertEqual(missing, [], f"Shopping.{missing} wywoływane, ale niezdefiniowane")
+
+
+class DeadIngredientsMenuTests(unittest.TestCase):
+    """P-5: pozycja menu 'Ingredients' prowadziła wyłącznie do toastu
+    'feature coming soon'."""
+
+    def test_menu_entry_is_gone(self) -> None:
+        self.assertNotIn("openIngredientsModal", RECIPES_HTML)
+
+    def test_dead_handler_and_its_toast_are_gone(self) -> None:
+        self.assertNotIn("function openIngredientsModal", RECIPES_JS)
+        self.assertNotIn("Ingredients feature coming soon", RECIPES_JS)
+
+
+class VisibilityPersistenceTests(unittest.TestCase):
+    """Behawioralne potwierdzenie P-1 po stronie API: is_public wysłane w
+    payloadzie faktycznie ląduje w bazie i wraca przy odczycie."""
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        db_path = Path(self._tmpdir.name) / "controls.db"
+        self._env_patch = mock.patch.dict(
+            os.environ,
+            {
+                "ENV": "dev",
+                "APP_INSTANCE": "dev",
+                "SECRET_KEY": "dev-secret",
+                "DATABASE_URL": f"sqlite:///{db_path}",
+                "MEAL_PLANNER_LOAD_ENV_FILE": "0",
+            },
+            clear=True,
+        )
+        self._env_patch.start()
+
+        import app.main as main_module
+        from fastapi.testclient import TestClient
+
+        from app.core.database import SessionLocal
+        from app.core.security import get_current_user
+        from app.db.models.user import User
+
+        self.main_module = main_module
+        self.db = SessionLocal()
+        self.user = User(username="controlsuser", hashed_password="x", role="user")
+        self.db.add(self.user)
+        self.db.commit()
+        self.db.refresh(self.user)
+
+        main_module.app.dependency_overrides[get_current_user] = lambda: self.user
+        self.client = TestClient(main_module.app)
+
+    def tearDown(self) -> None:
+        self.main_module.app.dependency_overrides.clear()
+        self.db.close()
+        from app.core.database import engine
+
+        engine.dispose()
+        self._env_patch.stop()
+        self._tmpdir.cleanup()
+        purge_app_modules()
+
+    def _create(self, is_public: bool) -> dict:
+        response = self.client.post(
+            "/api/v1/recipes/",
+            json={
+                "name": "Widoczność",
+                "description": "D",
+                "ingredients": "a",
+                "instructions": "I",
+                "is_public": is_public,
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()
+
+    def test_public_recipe_stays_public(self) -> None:
+        created = self._create(True)
+        self.assertTrue(created["is_public"])
+        self.assertTrue(self.client.get(f"/api/v1/recipes/{created['id']}").json()["is_public"])
+
+    def test_private_recipe_stays_private(self) -> None:
+        created = self._create(False)
+        self.assertFalse(created["is_public"])
+        self.assertFalse(self.client.get(f"/api/v1/recipes/{created['id']}").json()["is_public"])
+
+    def test_visibility_can_be_flipped_by_edit(self) -> None:
+        created = self._create(False)
+        updated = self.client.put(
+            f"/api/v1/recipes/{created['id']}",
+            json={
+                "name": "Widoczność",
+                "description": "D",
+                "ingredients": "a",
+                "instructions": "I",
+                "is_public": True,
+            },
+        )
+        self.assertEqual(updated.status_code, 200, updated.text)
+        self.assertTrue(updated.json()["is_public"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recipe_rendering_xss.py
+++ b/tests/test_recipe_rendering_xss.py
@@ -1,0 +1,210 @@
+"""Ochrona przed stored XSS w renderowaniu treści przepisu.
+
+Karta przepisu, lista składników, modal instrukcji i lista zakupów były sklejane
+jako HTML i przypisywane do innerHTML, więc treść przepisu wykonywała się jako
+kod. Przepis oznaczony jako publiczny jest serwowany innym użytkownikom, więc
+podatność nie kończy się na autorze.
+
+Projekt nie ma runnera JS (brak package.json, jsdom, Playwrighta), więc test
+frontendu jest tu statyczny: pilnuje, żeby niebezpieczny wzorzec nie wrócił do
+recipes.js. Dowód behawioralny (wstrzyknięty <img onerror> nie wykonuje się w
+przeglądarce) należy do smoke'u opisanego w opisie PR-a.
+
+Druga część to testy przez API: wroga i polska treść musi przechodzić przez
+zapis i odczyt bez zmian. Escapowanie należy do warstwy renderowania - baza i
+API mają oddawać dokładnie to, co dostały, żeby nie powstało podwójne
+escapowanie ani ciche gubienie znaków.
+"""
+import os
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+APP_DIR = Path(__file__).resolve().parent.parent / "app"
+RECIPES_JS = (APP_DIR / "static" / "recipes.js").read_text(encoding="utf-8")
+
+
+def purge_app_modules() -> None:
+    for name in list(sys.modules):
+        if name == "app" or name.startswith("app."):
+            sys.modules.pop(name)
+
+
+class RenderingSourceGuardTests(unittest.TestCase):
+    """Strażnik wzorca: żadna ścieżka renderowania nie może sklejać HTML-a
+    z danymi. Łapie regresję, w której ktoś dopisuje nową funkcję renderującą
+    starym stylem."""
+
+    def test_no_innerhtml_assignment_with_interpolation(self) -> None:
+        # innerHTML = `...${cokolwiek}...` - dokładnie ten wzorzec wykonywał
+        # <img src=x onerror=...> z nazwy przepisu.
+        offenders = re.findall(r"\.innerHTML\s*=\s*`[^`]*\$\{[^`]*`", RECIPES_JS, re.DOTALL)
+        self.assertEqual(offenders, [], f"innerHTML z interpolacją wrócił do recipes.js: {offenders}")
+
+    def test_no_innerhtml_assignment_with_concatenation(self) -> None:
+        offenders = re.findall(r"\.innerHTML\s*=\s*[^;`\n]*\+", RECIPES_JS)
+        self.assertEqual(offenders, [], f"innerHTML sklejany stringiem: {offenders}")
+
+    def test_no_other_html_parsing_sinks(self) -> None:
+        for sink in ("insertAdjacentHTML", "outerHTML =", "document.write"):
+            self.assertNotIn(sink, RECIPES_JS, f"Niebezpieczne API HTML w recipes.js: {sink}")
+
+    def test_recipe_card_is_built_through_dom_api(self) -> None:
+        self.assertIn("renderRecipeCard", RECIPES_JS)
+        # Helper el() ustawia treść wyłącznie przez textContent.
+        self.assertRegex(RECIPES_JS, r"function el\(tag, className, text\)")
+        self.assertRegex(RECIPES_JS, r"node\.textContent = String\(text\)")
+
+    def test_instructions_go_through_dataset_not_an_attribute_string(self) -> None:
+        # data-instructions="${r.instructions}" pozwalało wyjść z atrybutu
+        # cudzysłowem w treści instrukcji.
+        self.assertNotIn('data-instructions="${', RECIPES_JS)
+        self.assertIn("dataset.instructions", RECIPES_JS)
+
+    def test_instructions_modal_does_not_join_html(self) -> None:
+        self.assertNotIn('join("<br>")', RECIPES_JS)
+        self.assertIn('createElement("br")', RECIPES_JS)
+
+    def test_shopping_list_items_are_built_through_dom_api(self) -> None:
+        # item.name to linia składnika przepisu - ta sama niezaufana treść.
+        self.assertNotIn('<span class="item-name">${', RECIPES_JS)
+        self.assertIn('el("span", "item-name", item.name)', RECIPES_JS)
+
+
+class HostileContentRoundTripTests(unittest.TestCase):
+    """Treść wroga i treść normalna muszą przejść przez API bez zmian."""
+
+    HOSTILE = {
+        "script_tag": "<script>window.__x=1</script>",
+        "img_onerror": '<img src=x onerror="window.__x=1">',
+        "svg_onload": "<svg/onload=alert(1)>",
+        "attribute_breakout": '" onmouseover="window.__x=1',
+        "closing_tag": "</h3><b>injected</b>",
+    }
+
+    POLISH = {
+        "diacritics": "Żurek na zakwasie z jajkiem — pyszności",
+        "apostrophes": "Kurczak 'po polsku' i sos \"chrzanowy\"",
+        "ampersand": "Sól & pieprz < 5 g",
+    }
+
+    def setUp(self) -> None:
+        # ignore_cleanup_errors: SQLite trzyma uchwyt do pliku na Windows nawet
+        # po Session.close(), co inaczej wywala tearDown przed purge_app_modules.
+        self._tmpdir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        db_path = Path(self._tmpdir.name) / "xss.db"
+        self._env_patch = mock.patch.dict(
+            os.environ,
+            {
+                "ENV": "dev",
+                "APP_INSTANCE": "dev",
+                "SECRET_KEY": "dev-secret",
+                "DATABASE_URL": f"sqlite:///{db_path}",
+                "MEAL_PLANNER_LOAD_ENV_FILE": "0",
+            },
+            clear=True,
+        )
+        self._env_patch.start()
+
+        import app.main as main_module
+        from fastapi.testclient import TestClient
+
+        from app.core.database import SessionLocal
+        from app.core.security import get_current_user
+        from app.db.models.user import User
+
+        self.main_module = main_module
+        self.db = SessionLocal()
+        self.user = User(username="xssuser", hashed_password="x", role="user")
+        self.db.add(self.user)
+        self.db.commit()
+        self.db.refresh(self.user)
+
+        main_module.app.dependency_overrides[get_current_user] = lambda: self.user
+        self.client = TestClient(main_module.app)
+
+    def tearDown(self) -> None:
+        self.main_module.app.dependency_overrides.clear()
+        self.db.close()
+        from app.core.database import engine
+
+        engine.dispose()
+        self._env_patch.stop()
+        self._tmpdir.cleanup()
+        purge_app_modules()
+
+    def _round_trip(self, payload: str) -> dict:
+        created = self.client.post(
+            "/api/v1/recipes/",
+            json={
+                "name": payload,
+                "description": payload,
+                "instructions": payload,
+                "ingredients": f"{payload}\n1 cebula",
+                "is_public": True,
+            },
+        )
+        self.assertEqual(created.status_code, 200, created.text)
+        recipe_id = created.json()["id"]
+
+        fetched = self.client.get(f"/api/v1/recipes/{recipe_id}")
+        self.assertEqual(fetched.status_code, 200, fetched.text)
+        return fetched.json()
+
+    def test_hostile_payloads_survive_round_trip_verbatim(self) -> None:
+        for label, payload in self.HOSTILE.items():
+            with self.subTest(payload=label):
+                body = self._round_trip(payload)
+                self.assertEqual(body["name"], payload)
+                self.assertEqual(body["description"], payload)
+                self.assertEqual(body["instructions"], payload)
+                self.assertTrue(body["ingredients"].startswith(payload))
+
+    def test_polish_text_survives_round_trip_verbatim(self) -> None:
+        for label, payload in self.POLISH.items():
+            with self.subTest(payload=label):
+                body = self._round_trip(payload)
+                self.assertEqual(body["name"], payload)
+                self.assertEqual(body["description"], payload)
+
+    def test_hostile_name_is_not_double_escaped_on_the_way_out(self) -> None:
+        """Escapowanie należy do renderowania. Gdyby API zaczęło zwracać
+        &lt;script&gt;, użytkownik zobaczyłby encje jako tekst w nazwie
+        przepisu - to też jest błąd, tylko cichszy."""
+        body = self._round_trip(self.HOSTILE["script_tag"])
+        self.assertNotIn("&lt;", body["name"])
+        self.assertNotIn("&amp;", body["name"])
+
+    def test_hostile_content_survives_editing_too(self) -> None:
+        created = self.client.post(
+            "/api/v1/recipes/",
+            json={
+                "name": "Zwykła nazwa",
+                "description": "opis",
+                "instructions": "instrukcje",
+                "ingredients": "a",
+                "is_public": False,
+            },
+        )
+        recipe_id = created.json()["id"]
+
+        payload = self.HOSTILE["img_onerror"]
+        updated = self.client.put(
+            f"/api/v1/recipes/{recipe_id}",
+            json={
+                "name": payload,
+                "description": payload,
+                "instructions": payload,
+                "ingredients": payload,
+                "is_public": False,
+            },
+        )
+        self.assertEqual(updated.status_code, 200, updated.text)
+        self.assertEqual(updated.json()["name"], payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Co ten PR naprawia

Cztery znaleziska [audytu produktowego](docs/audits/product-audit-2026-08-07.md) i jeden błąd wykryty przy okazji — wszystkie w warstwie UI istniejącej produkcji. Diagnoza pochodzi z audytu brancha RC `feature/i18n-recipe-import-ingredients`, ale **żadna z tych wad nie jest regresją RC** — wszystkie są obecne na `main` dzisiaj.

### 1. Stored XSS w renderowaniu treści przepisu (blokujące)

Karta przepisu, lista składników, modal instrukcji i lista zakupów były sklejane jako HTML i przypisywane do `innerHTML`, więc treść przepisu wykonywała się jako kod. Przepis można oznaczyć jako publiczny, a wtedy `GET /api/v1/recipes/` serwuje go innym użytkownikom — podatność nie kończy się na autorze. Cookie `access_token` jest `HttpOnly`, ale XSS nadal pozwala działać w imieniu ofiary przez `fetch` do `/api/v1/*`.

Potwierdzone lokalnie: przepis o nazwie `Smoke PR1 <img src=x onerror="window.__XSS=1">` przed poprawką wstrzykiwał `<img>` i odpalał handler.

Naprawione **wszystkie** ścieżki renderowania naraz, nie jedno pole:

| Miejsce | Zmiana |
|---|---|
| `renderRecipeCard()` (nowa) | `createElement`/`textContent`; obrazek przez `.src`, instrukcje przez `dataset` |
| `renderIngredients()` | zwraca element zamiast stringa; `<span>` zostaje tuż za checkboxem, bo `addRecipeToShoppingList` czyta `nextElementSibling` |
| `renderRecipeBadge()` | zwraca element |
| `showInstructions()` | prawdziwe `<br>` i węzły tekstowe zamiast `join("<br>")` |
| `Shopping.render()` | pozycje listy przez DOM API — `item.name` to ta sama niezaufana linia składnika |
| reszta | `innerHTML = ""` → `replaceChildren()`, żeby wzorzec zniknął z pliku |

Struktura i nazwy klas bez zmian, więc CSS i delegacja zdarzeń działają jak poprzednio.

### 2. Zduplikowane `id="edit-is-public"` (P-2)

Występowało dwa razy — w formularzu dodawania i w modalu edycji. `getElementById` zwraca pierwszy, więc przełącznik w modalu edycji czytał i zapisywał cudzy element. Formularz dodawania dostaje `add-is-public`.

### 3. `is_public` przy dodawaniu przepisu (P-1)

`create()` nie wysyłało `is_public`, więc **każdy nowy przepis wychodził prywatny niezależnie od ustawienia przełącznika**. Naprawa wymaga punktu 2 — bez osobnego id nie ma czego odczytać. Dodatkowo `clearForm()` odznacza teraz checkboxy zamiast czyścić ich `.value` (co dla checkboxa nic nie robi), więc przełącznik nie zostaje włączony dla następnego przepisu.

### 4. Enter na liście zakupów

Handler `keydown` wołał `Shopping.addItem()` — metody o tej nazwie nigdy nie było w obiekcie `Shopping`. Enter rzucał `TypeError` i pozycja nie trafiała na listę, mimo że przycisk „Add" tuż obok działał.

### 5. Martwa pozycja „Ingredients" w menu (P-5)

Prowadziła wyłącznie do toastu „feature coming soon". Usunięta razem z `openIngredientsModal()`. Wraca, gdy będzie co pokazać.

## Czego ten PR NIE zawiera

Świadomie, żeby dało się go wdrożyć osobno:

- **żadnych migracji** i żadnego Alembica,
- **żadnych zmian w modelach** ani w schemacie bazy,
- **żadnego kodu importu z URL** (fetcher, SSRF guard, parser schema.org),
- **żadnych tłumaczeń przepisów** ani `recipe_translations`,
- **żadnego modelu składników** (`recipe_ingredients`, `ingredient_aliases`, `store_sections`),
- **żadnych nowych zależności** — `requirements.txt` nietknięty.

Zmienione pliki: `app/static/recipes.js`, `app/templates/recipes.html` + dwa nowe pliki testów.

## Wyniki testów

```
pytest tests/ -q   →   32 passed, 1 failed
```

Jedyna porażka: `test_app_smoke.py::test_app_can_be_created_without_network` — windowsowy `PermissionError` przy sprzątaniu tymczasowego pliku SQLite. **Przedistniejący, obecny na `main` przed tą zmianą**, niezwiązany z tym PR-em.

Dodane **24 testy** w dwóch plikach. Każdy zestaw sprawdzony pod kątem tego, czy faktycznie łapie regresję: **14 z nich jest czerwonych na nietkniętym `origin/main`**.

Projekt nie ma runnera JS (brak `package.json`, `jsdom`, Playwrighta), więc renderowania pilnują strażnicy wzorca nad źródłem `recipes.js` — `innerHTML` z interpolacją lub konkatenacją, `insertAdjacentHTML`, `outerHTML`, `document.write`, `data-instructions` jako string atrybutu, `join("<br>")`, pozycja listy zakupów sklejana z HTML. Skaner ignoruje komentarze, żeby wzmianka o naprawionym błędzie nie zapalała fałszywego alarmu.

Backend przez `TestClient`: `<script>`, `onerror`, `svg/onload`, wyjście z atrybutu i zamknięcie tagu oraz polskie znaki, apostrofy i ampersand muszą przechodzić zapis, odczyt i edycję bez zmian. Osobny test pilnuje, że API **nie** escapuje w drugą stronę — podwójne escapowanie pokazałoby użytkownikowi `&lt;script&gt;` jako tekst w nazwie przepisu.

Dodatkowo ogólniejszy strażnik: każde wywołanie `Shopping.foo()` musi wskazywać na metodę, którą obiekt naprawdę definiuje — to ten sam kształt błędu co `addItem`.

Pozostałe kontrole: `compileall` czysto, `node --check` czysto, `git diff --check` czysto.

## Smoke lokalny

Jednorazowa baza SQLite o kształcie produkcyjnym (64 przepisy, konto testowe), aplikacja na `127.0.0.1:8012`. **Bez kontaktu z VPS, RC i PostgreSQL.**

| Scenariusz | Wynik |
|---|---|
| Logowanie, lista 64 przepisów | renderuje się poprawnie (nagłówki, badge, składniki, przycisk „Manage" tylko dla właściciela) |
| Menu burger | bez martwej pozycji „Ingredients" |
| Dodanie przepisu z przełącznikiem PUBLIC | `is_public = 1` w bazie, badge „MY · PUBLIC" |
| Wroga treść w nazwie, opisie, instrukcji i składniku | `xssFired: false`, zero wstrzykniętych `<img>`/`<script>`/`<svg>` |
| Podwójne escapowanie | brak — `textContent` pokazuje oryginalny tekst |
| Polskie znaki, apostrofy, `&`, `<b>` | renderują się jako tekst, poprawnie |
| Modal instrukcji z cudzysłowami i `<svg/onload>` | tekst, jeden `<br>`, zero SVG |
| Lista zakupów z wrogą nazwą pozycji | bezpieczna, zero `<script>` w DOM |
| Enter w polu listy zakupów | pozycja dodana, pole wyczyszczone |
| Edycja: modal pokazuje prawdziwą widoczność i ją zapisuje | PUBLIC → PRIVATE zapisane |
| Usunięcie przepisu | 204, `GET` → 404 |
| Logi serwera i konsoli | brak tracebacków; jedyny 404 to celowe `GET` na usunięty przepis |

## Niezależność wdrożenia

Ten PR **może iść na obecną produkcję samodzielnie**:

- dotyka wyłącznie dwóch plików frontendu i dwóch nowych plików testów,
- nie wymaga migracji, backupu schematu ani okna serwisowego na bazę,
- nie zmienia API, kontraktów odpowiedzi, logowania, cookies, middleware ani konfiguracji,
- rollback to `git revert` jednego commitu kodu — bez kroku odwracania schematu,
- działa na obecnym schemacie produkcyjnym bez żadnych warunków wstępnych.

Jedyna widoczna zmiana zachowania poza naprawą błędów: znika pozycja „Ingredients" z menu burger.

## Kontekst

Pierwszy z sześciu pakietów, na jakie dzielony jest branch RC. Kolejne (Alembic, i18n UI, import z URL, tłumaczenia treści) będą osobnymi PR-ami. Pełna diagnoza: [audyt RC](docs/audits/rc-audit-i18n-recipe-import-2026-08-07.md) — plik jest na branchu `fix/meal-rc-release-blockers`, jeszcze nie na `main`.

Ten PR **nie jest przeznaczony do merge'a bez akceptacji** — proszę o review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)