### PR TITLE
docs: align deployment runbook with current Meal Planner state

### DIFF
--- a/docs/operations/deployment-history.md
+++ b/docs/operations/deployment-history.md
@@ -1,0 +1,27 @@
+# Meal Planner Deployment History
+
+Ten dokument jest rejestrem potwierdzonych punktów wdrożeniowych, a nie
+guardrailem wymagającym konkretnego SHA. Aktualny stan należy zawsze sprawdzić
+odczytowo na VPS i w `origin/main`.
+
+## Potwierdzone punkty
+
+* 2026-08-07 — produkcja po PR #15: `a734342`.
+* 2026-08-08 — `origin/main` po scaleniu PR #17: `0443a4f`.
+* 2026-08-08 — RC po walidacji PR #16: PostgreSQL `fastapi_db_rc`,
+  `alembic current=head=69eea78ac02c`, `alembic check` czysty; test kaskady
+  zakończony powodzeniem.
+* 2026-08-08 — PR #16 i PR #17 oczekują na osobne wdrożenie produkcyjne;
+  PR #17 wymaga pełnego smoke UI PL/EN na świeżej linii RC.
+
+## Reguła aktualizacji
+
+Przed każdym wdrożeniem zapisz w raporcie:
+
+1. `git rev-parse HEAD` produkcyjnego checkoutu;
+2. `git rev-parse origin/main`;
+3. wynik `git log --oneline` i ocenę, które zatwierdzone PR-y obejmuje różnica;
+4. wynik kontroli schematu oraz backupu.
+
+Historyczne SHA mogą pozostać w audytach i wpisach tego rejestru, ale muszą być
+opisane datą oraz jako stan historyczny.

--- a/docs/operations/production-environment.md
+++ b/docs/operations/production-environment.md
@@ -1,6 +1,6 @@
 # Production Environment
 
-Data aktualizacji: 2026-08-04
+Data aktualizacji: 2026-08-08
 
 > Aktualny stan operacyjny i ograniczenia zmian opisuje [Production Guardrails](production-guardrails.md). Ten dokument zawiera również informacje historyczne i nie zastępuje obserwacji z VPS.
 
@@ -8,7 +8,9 @@ Data aktualizacji: 2026-08-04
 
 - Checkout: `/var/www/meal-planner`
 - Branch: `main`
-- Commit: `feacd6c`
+- Commit produkcji przed planowanym wdrożeniem: `a734342` (PR #15)
+- Zaakceptowany `origin/main`: `0443a4f` (PR #17)
+- Oczekujące na wdrożenie: PR #16 (Alembic/schemat) i PR #17 (UI PL/EN)
 - Proces: `uvicorn app.main:app --host 0.0.0.0 --port 8000`
 - Usługa: `meal-planner.service`
 - Reverse proxy: `nginx`
@@ -37,7 +39,7 @@ Data aktualizacji: 2026-08-04
   [alembic-migrations.md](alembic-migrations.md)
 - `.env` wskazuje SQLite, choć runtime działa na PostgreSQL
 - brak health/ready endpointów
-- produkcja nie została zmieniona w Sprincie 0 na VPS; checkout i usługa pozostają bez restartu
+- starsze wpisy tego dokumentu i audytów opisują stan historyczny; bieżący stan commitów należy zawsze potwierdzać przez `git rev-parse HEAD` oraz `git rev-parse origin/main`
 
 ## Polecenia tylko do odczytu
 

--- a/docs/operations/production-guardrails.md
+++ b/docs/operations/production-guardrails.md
@@ -1,6 +1,6 @@
 # Production Guardrails
 
-Data obserwacji: 2026-08-07 UTC.
+Data obserwacji: 2026-08-08 UTC.
 
 ## Cel
 
@@ -8,8 +8,9 @@ Ten dokument jest obowiązkową instrukcją dla osób i agentów pracujących na
 
 ## Źródła prawdy
 
-* Kod uruchomiony na produkcji: `/var/www/meal-planner`, obecnie commit `9e64b73e1ee84eed4e296ee09dac7844005e0ceb`.
-* Kod w GitHubie: remote `origin`; na dzień obserwacji `origin/main` wskazuje `feacd6c51e5d562a0568244f63d577aa3323581d` i nie jest tym samym stanem co uruchomiona produkcja. Nie zakładaj, że `main` jest źródłem aktualnego runtime.
+* Kod uruchomiony na produkcji przed kolejnym planowanym wdrożeniem: `/var/www/meal-planner`, commit `a734342` (PR #15).
+* Zaakceptowany punkt wejścia do kolejnej walidacji: `origin/main` commit `0443a4f` (PR #17, z PR #15 i #16 w historii). PR #16 i #17 nie są jeszcze wdrożone na produkcji.
+* Przy każdym wdrożeniu odczytaj `HEAD` checkoutu i `origin/main`, zapisz oba hashe w raporcie preflight i oceń różnicę względem zatwierdzonych PR-ów. Żaden konkretny SHA nie jest trwałym guardrailem.
 * Konfiguracja produkcji: systemd, `/var/www/meal-planner/.env` oraz aktywny plik Nginx na VPS. Wartości sekretów pozostają wyłącznie na VPS.
 * Dokumentacja: pliki `docs/` w repo, z zastrzeżeniem, że starsze audyty mogą opisywać stan historyczny.
 * Dane i konta: PostgreSQL `fastapi_db` na localhost, tabele aplikacyjne `users`, `recipes`, `ingredients`, `login_log`, `request_log`.
@@ -123,7 +124,8 @@ Rollback aplikacji jest ręczny i nie jest obecnie pełnym, automatycznym mechan
 
 ## Znane ograniczenia i dług techniczny
 
-* `/var/www/meal-planner` jest osobnym produkcyjnym checkoutem; aktywny commit nie jest aktualnym `origin/main`.
+* `/var/www/meal-planner` jest osobnym produkcyjnym checkoutem; przed planowanym wdrożeniem jest na `a734342`, trzy commity za zaakceptowanym `origin/main=0443a4f`.
+* Wartości `9e64b73`, `feacd6c` i wcześniejsze SHA występują w starszych audytach jako historia obserwacji/wdrożeń, nie jako aktualne wymagania.
 * Istnieją trzy checkouty Meal Plannera: produkcyjny `/var/www/meal-planner`, RC `/var/www/meal-planner-rc` oraz roboczy `/home/deploy/meal-planner-sprint-0`; ich role nie wynikają z samej nazwy katalogu.
 * RC jest obecnie zatrzymany i ma wyłączony autostart.
 * Część starszych dokumentów opisuje historyczną konfigurację i wymaga aktualizacji; ten dokument opisuje obserwację z 2026-08-07.

--- a/docs/operations/rc-environment.md
+++ b/docs/operations/rc-environment.md
@@ -1,12 +1,13 @@
 # RC Environment
 
-Data aktualizacji: 2026-08-04
+Data aktualizacji: 2026-08-08
 
 ## Stan bieżący
 
 - Checkout RC na VPS: `/var/www/meal-planner-rc`
-- Branch checkoutu RC po wdrożeniu Sprint 0: `chore/meal-planner-sprint-0`
-- Commit checkoutu RC po wdrożeniu Sprint 0: `cf9f17c`
+- Branch checkoutu RC przed odświeżeniem PR #17: `rc/meal-alembic-foundation-validation`
+- Commit checkoutu RC przed odświeżeniem: `b733644`
+- Docelowy branch walidacyjny PR #17: `rc/meal-ui-i18n-validation`, tworzony bezpośrednio z `origin/main=0443a4f`
 - Usługa systemowa: `meal-planner-rc.service`
 - WorkingDirectory usługi: `/var/www/meal-planner-rc`
 - Port usługi: `127.0.0.1:8001`
@@ -39,6 +40,12 @@ Data aktualizacji: 2026-08-04
 - autostart usługi został wyłączony,
 - po smoke usługa RC została zatrzymana,
 - produkcja pozostała bez zmian.
+
+## Stan przed walidacją PR #17
+
+- `origin/main=0443a4f` zawiera PR #15, PR #16 i PR #17.
+- RC PostgreSQL ma `current=head=69eea78ac02c` i `alembic check` nie wykazuje driftu.
+- PR #17 wymaga jeszcze smoke UI PL/EN; nie należy traktować go jako wdrożonego na produkcji.
 
 ## Sprawdzona bezpieczna ścieżka testowa
 


### PR DESCRIPTION
## Cel

Uaktualnić dokumentację operacyjną Meal Plannera do rzeczywistego stanu VPS i rozdzielić bieżący stan wdrożeniowy od historycznych commitów.

## Stan faktyczny

- produkcja: `a734342` — PR #15,
- `origin/main`: `0443a4f` — zawiera PR #16 i PR #17,
- RC: baza `fastapi_db_rc`, Alembic `69eea78ac02c`, usługa zatrzymana i wyłączona,
- PR #16 i #17 nie są jeszcze wdrożone produkcyjnie.

## Zmiany

- aktualizacja `docs/operations/production-guardrails.md`,
- aktualizacja `docs/operations/production-environment.md`,
- aktualizacja `docs/operations/rc-environment.md`,
- dodanie/aktualizacja `docs/operations/deployment-history.md`,
- usunięcie trwałego założenia, że konkretny SHA jest guardrailem,
- wprowadzenie obowiązku odczytu `HEAD` i `origin/main` podczas preflightu oraz świadomej oceny różnicy.

## Weryfikacja

- `git diff --check` — OK,
- branch oparty na aktualnym `origin/main`,
- zmiany wyłącznie dokumentacyjne,
- brak zmian w aplikacji, bazie, nginx, sekretach i usługach.

PR nie wdraża produkcji i nie rozpoczyna PR #4.