### PR TITLE
fix: usuń obraz przepisu po usunięciu rekordu

### DIFF
--- a/app/services/recipe_service.py
+++ b/app/services/recipe_service.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, timedelta
 
 from sqlalchemy.orm import Session
@@ -10,8 +11,10 @@ from app.schemas.recipe import RecipeCreate, RecipeVisibilityUpdate
 from app.schemas.recipe import RecipeRead
 from app.services.ingredient_parsing.parser import NEEDS_REVIEW_THRESHOLD
 from app.services.permissions_service import require_owner_or_admin
+from app.utils.file_utils import delete_image
 
 DUPLICATE_IMPORT_WINDOW_SECONDS = 120
+logger = logging.getLogger(__name__)
 
 
 def to_recipe_read(db: Session, recipe: Recipe, language: str, **extra) -> RecipeRead:
@@ -190,5 +193,18 @@ def delete_recipe(db: Session, recipe: Recipe, user):
     """Usuwa przepis po autoryzacji."""
     require_owner_or_admin(recipe, user)
 
+    image = recipe.image
     db.delete(recipe)
     db.commit()
+
+    # The database row is already gone. Image cleanup is best effort so a
+    # filesystem issue does not turn a successful delete into a misleading
+    # 500. Log only the recipe id; never expose the stored path.
+    if image:
+        try:
+            delete_image(image)
+        except OSError:
+            logger.warning(
+                "Could not remove image after recipe deletion",
+                extra={"recipe_id": recipe.id},
+            )

--- a/tests/test_recipe_delete_cascade.py
+++ b/tests/test_recipe_delete_cascade.py
@@ -295,6 +295,21 @@ class RecipeDeleteCascadeTests(unittest.TestCase):
         self.assertEqual(orphan_translations, [])
         self.assertEqual(orphan_ingredients, [])
 
+    def test_delete_recipe_removes_attached_image_after_commit(self) -> None:
+        """Deleting a recipe must not leave its uploaded image orphaned."""
+        from app.services import recipe_service
+
+        recipe = self._make_recipe()
+        recipe.image = "/static/uploads/recipe-delete-test.webp"
+        self.db.commit()
+        recipe_id = recipe.id
+
+        with mock.patch("app.services.recipe_service.delete_image") as delete_image:
+            recipe_service.delete_recipe(self.db, recipe, self.user)
+
+        self.assertIsNone(recipe_service.get_recipe_by_id(self.db, recipe_id))
+        delete_image.assert_called_once_with("/static/uploads/recipe-delete-test.webp")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Cel

Domknąć lifecycle obrazów przepisów po post-release checkpoincie Recipe Import.

## Problem

Usunięcie `Recipe` usuwało rekord z bazy, ale pozostawiało plik wskazany przez `Recipe.image`, przez co po normalnym DELETE mogły powstawać osierocone uploady.

## Zmiana

- cleanup obrazu wykonywany dopiero po udanym commitcie DELETE,
- błąd systemu plików nie powoduje fałszywego HTTP 500 po poprawnym usunięciu rekordu,
- logowanie ograniczone do `recipe_id`, bez ujawniania ścieżki pliku,
- test regresyjny lifecycle obrazu przy usuwaniu przepisu.

## Zakres

PR nie zawiera:

- zmian migracji lub schematu,
- zmian Recipe Import,
- zmian Ingredient Engine,
- przebudowy listy zakupów,
- deploymentu produkcyjnego.

## Weryfikacja

- pełna suite: `231 passed`, `26 subtests passed`,
- `compileall` — OK,
- `node --check` — OK,
- `git diff --check` — OK,
- Alembic `current = head = 69eea78ac02c`,
- `alembic check` — czysto.

## Kontekst operacyjny

W ramach checkpointu:

- skorygowano drift `users_id_seq` po zweryfikowanym backupie,
- dwa potwierdzone osierocone pliki przeniesiono do kwarantanny,
- nie wykonywano heurystycznego czyszczenia pozostałych uploadów,
- produkcja nie była restartowana ani wdrażana przez ten branch.
